### PR TITLE
add more complete data from redfish

### DIFF
--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/048c2acc-cc3f-422e-88e2-ed1ffb48e4c9.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/048c2acc-cc3f-422e-88e2-ed1ffb48e4c9.json
@@ -18,38 +18,45 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:36",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 0,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:37",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:b6",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:b7",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +68,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/04d91a7a-db07-4d15-8958-10127b145ac3.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/04d91a7a-db07-4d15-8958-10127b145ac3.json
@@ -18,38 +18,47 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:44:02:86",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:44:02:87",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d7:90",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
+      "rate": 1000000000,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d7:91",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +70,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/11159aeb-c92b-42e0-bf27-1b9f9722343e.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/11159aeb-c92b-42e0-bf27-1b9f9722343e.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:c6",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:c7",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:66",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:67",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/16035a48-fc53-4b5f-87fc-f911569545da.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/16035a48-fc53-4b5f-87fc-f911569545da.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:21:6e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:21:6f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:62",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:63",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/16cf13d6-3aa3-4c43-a68a-732ddefe9bc5.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/16cf13d6-3aa3-4c43-a68a-732ddefe9bc5.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:26:fe",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:26:ff",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:24",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:25",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/1ae67ba9-1a5c-455d-9f6e-70ee8e6ed7c4.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/1ae67ba9-1a5c-455d-9f6e-70ee8e6ed7c4.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:37:46",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:37:47",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:60",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:61",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/1c68ca65-2a29-4c4d-a9ea-6d20a447cdfa.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/1c68ca65-2a29-4c4d-a9ea-6d20a447cdfa.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:2d:96",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:2d:97",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:9e",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:9f",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/21e3f190-ee10-4c38-aceb-64468a2355ef.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/21e3f190-ee10-4c38-aceb-64468a2355ef.json
@@ -14,66 +14,78 @@
     "name": "PowerEdge R840",
     "serial": "591TJD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "3792 GiB",
     "ram_size": 3792000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "2c:ea:7f:eb:7e:14",
+      "management": false,
       "model": "BRCM GbE 4P 5720-t rNDC",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "2c:ea:7f:eb:7e:15",
+      "management": false,
       "model": "BRCM GbE 4P 5720-t rNDC",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-3",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "2c:ea:7f:eb:7e:16",
+      "management": false,
       "model": "BRCM GbE 4P 5720-t rNDC",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-4",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "2c:ea:7f:eb:7e:17",
+      "management": false,
       "model": "BRCM GbE 4P 5720-t rNDC",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.4-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "04:3f:72:ff:9b:da",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 Adpt",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.4-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "04:3f:72:ff:9b:db",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 Adpt",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "InfiniBand.Slot.2-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:73:47:12",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -85,13 +97,16 @@
   },
   "processor": {
     "cache_l1": 1792000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 28672000,
     "cache_l3": 39424000,
     "clock_speed": 2200000000,
-    "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Platinum 8276 CPU @ 2.20GHz",
+    "instruction_set": null,
+    "model": null,
+    "other_description": "Intel(R) Xeon(R) Platinum 8276 CPU @ 2.20GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/30fd8160-939f-4ba6-8c85-deb4df593d61.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/30fd8160-939f-4ba6-8c85-deb4df593d61.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76D1KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:9e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:9f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:e6",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:e7",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:44:70",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/32c3403a-a47f-47bf-bc69-35f206d157c2.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/32c3403a-a47f-47bf-bc69-35f206d157c2.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:46:5e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:46:5f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:9a",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:9b",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/3e79e685-1a53-48ed-a67f-6afb03572839.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/3e79e685-1a53-48ed-a67f-6afb03572839.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76D3KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:fe",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:ff",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:dc:9c",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:dc:9d",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:4b:0f:fc",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/41228e00-5d2b-42cb-a373-e532bb1be2da.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/41228e00-5d2b-42cb-a373-e532bb1be2da.json
@@ -17,61 +17,72 @@
   "gpu": {
     "gpu": true,
     "gpu_count": 4,
-    "gpu_model": "GV100GL [Tesla V100 SXM2 32GB]",
+    "gpu_model": "V100",
+    "gpu_name": "GV100GL [Tesla V100 SXM2 32GB]",
     "gpu_vendor": "NVIDIA Corporation"
   },
   "main_memory": {
     "humanized_ram_size": "128 GiB",
     "ram_size": 128000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:43:4b:b8:f5:ba",
+      "management": false,
       "model": "Intel(R) 2P X710/2P I350 rNDC",
-      "rate": 0,
       "vendor": "Intel Corporation"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:43:4b:b8:f5:bc",
+      "management": false,
       "model": "Intel(R) 2P X710/2P I350 rNDC",
-      "rate": 0,
       "vendor": "Intel Corporation"
     },
     {
       "device": "NIC.Integrated.1-3",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:43:4b:b8:f5:da",
+      "management": false,
       "model": "Intel(R) 2P X710/2P I350 rNDC",
-      "rate": 0,
       "vendor": "Intel Corporation"
     },
     {
       "device": "NIC.Integrated.1-4",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:43:4b:b8:f5:db",
+      "management": false,
       "model": "Intel(R) 2P X710/2P I350 rNDC",
-      "rate": 0,
       "vendor": "Intel Corporation"
     },
     {
       "device": "NIC.Slot.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:1d:d1:32",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX Adpt",
-      "rate": 0,
+      "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:1d:d1:33",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX Adpt",
-      "rate": 0,
+      "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -83,11 +94,14 @@
   },
   "processor": {
     "cache_l1": 1280000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 20480000,
     "cache_l3": 28160000,
     "clock_speed": 2100000000,
-    "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz",
+    "instruction_set": null,
+    "model": null,
+    "other_description": "Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz",
     "vendor": "Intel",
     "version": null
   },

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/45dfcaba-0816-46b7-aa50-c62a32b1c1df.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/45dfcaba-0816-46b7-aa50-c62a32b1c1df.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R6525",
     "serial": "847XJD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",
     "ram_size": 256000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Embedded.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:d0:a3:46",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Embedded.2-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:d0:a3:47",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c6:6e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c6:6f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "InfiniBand.Slot.2-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "0c:42:a1:19:52:8a",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 12288000,
     "cache_l3": 131072000,
     "clock_speed": 2300000000,
     "instruction_set": "x86-64",
-    "model": "AMD EPYC 7352 24-Core Processor",
+    "model": "AMD EPYC",
+    "other_description": "AMD EPYC 7352 24-Core Processor",
     "vendor": "AMD",
-    "version": null
+    "version": "Model 49 Stepping 0"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/4ad28a72-c19d-47d1-ae09-e54b77ed39d1.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/4ad28a72-c19d-47d1-ae09-e54b77ed39d1.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R6525",
     "serial": "84710D3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",
     "ram_size": 256000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Embedded.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:d0:a4:78",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Embedded.2-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:d0:a4:79",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c4:f6",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c4:f7",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "InfiniBand.Slot.2-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "0c:42:a1:19:4d:72",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 12288000,
     "cache_l3": 131072000,
     "clock_speed": 2300000000,
     "instruction_set": "x86-64",
-    "model": "AMD EPYC 7352 24-Core Processor",
+    "model": "AMD EPYC",
+    "other_description": "AMD EPYC 7352 24-Core Processor",
     "vendor": "AMD",
-    "version": null
+    "version": "Model 49 Stepping 0"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/5bc4b84d-e791-42bf-862e-f46a25fd7b63.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/5bc4b84d-e791-42bf-862e-f46a25fd7b63.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76H3KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:51:ee",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:51:ef",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:0c",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:0d",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:42:ac",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/5c244193-2981-4108-9003-be53f3548123.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/5c244193-2981-4108-9003-be53f3548123.json
@@ -18,38 +18,44 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:37:26",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 0,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:37:27",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:4c",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:4d",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,15 +67,29 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
-  "storage_devices": [],
+  "storage_devices": [
+    {
+      "device": "Disk.Bay.0:Enclosure.Internal.0-1:NonRAID.Slot.6-1",
+      "humanized_size": "480 GB",
+      "interface": "SATA",
+      "media_type": "SSD",
+      "model": "SSDSC2KB480G8R",
+      "rev": "XCV1DL69",
+      "size": 480103981056,
+      "vendor": "INTEL"
+    }
+  ],
   "supported_job_types": {
     "besteffort": false,
     "deploy": true,

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/65c744bb-81ea-4fa8-a5f7-998dc315b4f9.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/65c744bb-81ea-4fa8-a5f7-998dc315b4f9.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76H4KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:56",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:57",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:5e",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:5f",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:43:94",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/6a75c2df-eabe-41aa-98ac-c1e25bebc738.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/6a75c2df-eabe-41aa-98ac-c1e25bebc738.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:46:b6",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:46:b7",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:dc:58",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:dc:59",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/6d8a9b9d-6eb9-4c36-a287-93df514f4c75.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/6d8a9b9d-6eb9-4c36-a287-93df514f4c75.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:2c:2e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:2c:2f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:1c",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:1d",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/6f8e4223-5141-479d-a452-5f4484cdaeb8.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/6f8e4223-5141-479d-a452-5f4484cdaeb8.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R6525",
     "serial": "846YJD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",
     "ram_size": 256000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Embedded.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:ef:ea:88",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Embedded.2-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:ef:ea:89",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:ee",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:ef",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "InfiniBand.Slot.2-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "0c:42:a1:19:4d:4a",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 12288000,
     "cache_l3": 131072000,
     "clock_speed": 2300000000,
     "instruction_set": "x86-64",
-    "model": "AMD EPYC 7352 24-Core Processor",
+    "model": "AMD EPYC",
+    "other_description": "AMD EPYC 7352 24-Core Processor",
     "vendor": "AMD",
-    "version": null
+    "version": "Model 49 Stepping 0"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/74dd50fb-fef6-4fb8-9611-4ce6330cbd4c.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/74dd50fb-fef6-4fb8-9611-4ce6330cbd4c.json
@@ -18,38 +18,45 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:55:f8:72",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 0,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:55:f8:73",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:dc:ae",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:dc:af",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +68,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/75bd70e1-155b-4c53-93cf-c9746c42cfb8.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/75bd70e1-155b-4c53-93cf-c9746c42cfb8.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R6525",
     "serial": "84700D3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",
     "ram_size": 256000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Embedded.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:ef:eb:76",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Embedded.2-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:ef:eb:77",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c6:76",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c6:77",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "InfiniBand.Slot.2-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "0c:42:a1:19:4d:8a",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 12288000,
     "cache_l3": 131072000,
     "clock_speed": 2300000000,
     "instruction_set": "x86-64",
-    "model": "AMD EPYC 7352 24-Core Processor",
+    "model": "AMD EPYC",
+    "other_description": "AMD EPYC 7352 24-Core Processor",
     "vendor": "AMD",
-    "version": null
+    "version": "Model 49 Stepping 0"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/7b51e341-8cce-4f78-936c-b6756e6bcd0d.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/7b51e341-8cce-4f78-936c-b6756e6bcd0d.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R6525",
     "serial": "847SJD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",
     "ram_size": 256000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Embedded.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:d0:a4:cc",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Embedded.2-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:d0:a4:cd",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:d6",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:d7",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "InfiniBand.Slot.2-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "0c:42:a1:19:4d:52",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 12288000,
     "cache_l3": 131072000,
     "clock_speed": 2300000000,
     "instruction_set": "x86-64",
-    "model": "AMD EPYC 7352 24-Core Processor",
+    "model": "AMD EPYC",
+    "other_description": "AMD EPYC 7352 24-Core Processor",
     "vendor": "AMD",
-    "version": null
+    "version": "Model 49 Stepping 0"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/7ed407a7-98dd-4708-bf32-9e0ab50c9f68.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/7ed407a7-98dd-4708-bf32-9e0ab50c9f68.json
@@ -100,6 +100,16 @@
       "rev": "1.1.1",
       "size": 960197124096,
       "vendor": "Toshiba"
+    },
+    {
+      "device": "PCIeSSD.Slot.1-1",
+      "humanized_size": "2000 GB",
+      "interface": "PCIe",
+      "media_type": "SSD",
+      "model": "Force MP600",
+      "rev": "EGFM13.0",
+      "size": 2000381018112,
+      "vendor": "Phison"
     }
   ],
   "supported_job_types": {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/7ed407a7-98dd-4708-bf32-9e0ab50c9f68.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/7ed407a7-98dd-4708-bf32-9e0ab50c9f68.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R6525",
     "serial": "846ZJD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",
     "ram_size": 256000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Embedded.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:ef:e3:4c",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Embedded.2-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:ef:e3:4d",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:be",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:bf",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "InfiniBand.Slot.2-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "0c:42:a1:19:4d:5a",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 12288000,
     "cache_l3": 131072000,
     "clock_speed": 2300000000,
     "instruction_set": "x86-64",
-    "model": "AMD EPYC 7352 24-Core Processor",
+    "model": "AMD EPYC",
+    "other_description": "AMD EPYC 7352 24-Core Processor",
     "vendor": "AMD",
-    "version": null
+    "version": "Model 49 Stepping 0"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/81da739b-d3e5-466f-aa84-a04187412723.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/81da739b-d3e5-466f-aa84-a04187412723.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:27:0e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:27:0f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d9:54",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d9:55",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/868ba245-c229-4073-875f-46837f987de8.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/868ba245-c229-4073-875f-46837f987de8.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R6525",
     "serial": "847VJD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",
     "ram_size": 256000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Embedded.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:ef:eb:d8",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Embedded.2-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:ef:eb:d9",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:e6",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:e7",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "InfiniBand.Slot.2-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "0c:42:a1:19:4d:3a",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 12288000,
     "cache_l3": 131072000,
     "clock_speed": 2300000000,
     "instruction_set": "x86-64",
-    "model": "AMD EPYC 7352 24-Core Processor",
+    "model": "AMD EPYC",
+    "other_description": "AMD EPYC 7352 24-Core Processor",
     "vendor": "AMD",
-    "version": null
+    "version": "Model 49 Stepping 0"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/89e48f7e-d04f-4455-b093-2a4318fb7026.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/89e48f7e-d04f-4455-b093-2a4318fb7026.json
@@ -14,6 +14,12 @@
     "name": "PowerEdge R740",
     "serial": "76D4KD3"
   },
+  "fpga": {
+    "board_model": "Alveo U280",
+    "board_vendor": "Xilinx Corporation",
+    "fpga_model": "XCU280",
+    "fpga_vendor": "Xilinx Corporation"
+  },
   "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/89e48f7e-d04f-4455-b093-2a4318fb7026.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/89e48f7e-d04f-4455-b093-2a4318fb7026.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76D4KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:e6",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:e7",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d7:c8",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d7:c9",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:43:90",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/8de50d9d-0de8-4f13-a2d2-a2d7e666f952.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/8de50d9d-0de8-4f13-a2d2-a2d7e666f952.json
@@ -17,59 +17,70 @@
   "gpu": {
     "gpu": true,
     "gpu_count": 4,
-    "gpu_model": "GV100GL [Tesla V100 SXM2 32GB]",
+    "gpu_model": "V100",
+    "gpu_name": "GV100GL [Tesla V100 SXM2 32GB]",
     "gpu_vendor": "NVIDIA Corporation"
   },
   "main_memory": {
     "humanized_ram_size": "128 GiB",
     "ram_size": 128000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:43:4b:b8:f8:22",
+      "management": false,
       "model": "Intel(R) 2P X710/2P I350 rNDC",
-      "rate": 0,
       "vendor": "Intel Corporation"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:43:4b:b8:f8:24",
+      "management": false,
       "model": "Intel(R) 2P X710/2P I350 rNDC",
-      "rate": 0,
       "vendor": "Intel Corporation"
     },
     {
       "device": "NIC.Integrated.1-3",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:43:4b:b8:f8:42",
+      "management": false,
       "model": "Intel(R) 2P X710/2P I350 rNDC",
-      "rate": 0,
       "vendor": "Intel Corporation"
     },
     {
       "device": "NIC.Integrated.1-4",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:43:4b:b8:f8:43",
+      "management": false,
       "model": "Intel(R) 2P X710/2P I350 rNDC",
-      "rate": 0,
       "vendor": "Intel Corporation"
     },
     {
       "device": "NIC.Slot.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:1d:d6:2a",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX Adpt",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:1d:d6:2b",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX Adpt",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
@@ -83,11 +94,14 @@
   },
   "processor": {
     "cache_l1": 1280000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 20480000,
     "cache_l3": 28160000,
     "clock_speed": 2100000000,
-    "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz",
+    "instruction_set": null,
+    "model": null,
+    "other_description": "Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz",
     "vendor": "Intel",
     "version": null
   },

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/926a9c99-3b27-45a7-818c-e6525b9ce89c.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/926a9c99-3b27-45a7-818c-e6525b9ce89c.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76F0KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:44:0f:56",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:44:0f:57",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:da:1c",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:da:1d",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:43:3c",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/926a9c99-3b27-45a7-818c-e6525b9ce89c.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/926a9c99-3b27-45a7-818c-e6525b9ce89c.json
@@ -14,6 +14,12 @@
     "name": "PowerEdge R740",
     "serial": "76F0KD3"
   },
+  "fpga": {
+    "board_model": "Alveo U280",
+    "board_vendor": "Xilinx Corporation",
+    "fpga_model": "XCU280",
+    "fpga_vendor": "Xilinx Corporation"
+  },
   "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/99732d8f-3f6c-4602-985a-35aff2657b6c.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/99732d8f-3f6c-4602-985a-35aff2657b6c.json
@@ -17,59 +17,70 @@
   "gpu": {
     "gpu": true,
     "gpu_count": 4,
-    "gpu_model": "GV100GL [Tesla V100 SXM2 32GB]",
+    "gpu_model": "V100",
+    "gpu_name": "GV100GL [Tesla V100 SXM2 32GB]",
     "gpu_vendor": "NVIDIA Corporation"
   },
   "main_memory": {
     "humanized_ram_size": "119 GiB",
     "ram_size": 119000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:43:4b:b8:ff:0e",
+      "management": false,
       "model": "Intel(R) 2P X710/2P I350 rNDC",
-      "rate": 0,
       "vendor": "Intel Corporation"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:43:4b:b8:ff:10",
+      "management": false,
       "model": "Intel(R) 2P X710/2P I350 rNDC",
-      "rate": 0,
       "vendor": "Intel Corporation"
     },
     {
       "device": "NIC.Integrated.1-3",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:43:4b:b8:ff:2e",
+      "management": false,
       "model": "Intel(R) 2P X710/2P I350 rNDC",
-      "rate": 0,
       "vendor": "Intel Corporation"
     },
     {
       "device": "NIC.Integrated.1-4",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:43:4b:b8:ff:2f",
+      "management": false,
       "model": "Intel(R) 2P X710/2P I350 rNDC",
-      "rate": 0,
       "vendor": "Intel Corporation"
     },
     {
       "device": "NIC.Slot.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:1d:d8:42",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX Adpt",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:1d:d8:43",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX Adpt",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
@@ -83,11 +94,14 @@
   },
   "processor": {
     "cache_l1": 1280000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 20480000,
     "cache_l3": 28160000,
     "clock_speed": 2100000000,
-    "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz",
+    "instruction_set": null,
+    "model": null,
+    "other_description": "Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz",
     "vendor": "Intel",
     "version": null
   },

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/9a3d528e-b7ed-407e-bbf0-4bac74161204.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/9a3d528e-b7ed-407e-bbf0-4bac74161204.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R6525",
     "serial": "847WJD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",
     "ram_size": 256000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Embedded.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:d0:a1:b2",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Embedded.2-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:d0:a1:b3",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:ae",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:af",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "InfiniBand.Slot.2-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "0c:42:a1:19:4d:6a",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 12288000,
     "cache_l3": 131072000,
     "clock_speed": 2300000000,
     "instruction_set": "x86-64",
-    "model": "AMD EPYC 7352 24-Core Processor",
+    "model": "AMD EPYC",
+    "other_description": "AMD EPYC 7352 24-Core Processor",
     "vendor": "AMD",
-    "version": null
+    "version": "Model 49 Stepping 0"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/9ae9a4bd-5157-4f6b-930d-ea5739ff86f6.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/9ae9a4bd-5157-4f6b-930d-ea5739ff86f6.json
@@ -14,50 +14,58 @@
     "name": "PowerEdge R740",
     "serial": "76D8KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:44:00:36",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:44:00:37",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:40",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:41",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:43:48",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,26 +77,18 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
-  "storage_devices": [
-    {
-      "device": "Disk.Bay.0:Enclosure.Internal.0-1:NonRAID.Slot.6-1",
-      "humanized_size": "480 GB",
-      "interface": "SATA",
-      "media_type": "SSD",
-      "model": "SSDSC2KB480G8R",
-      "rev": "XCV1DL69",
-      "size": 480103980544,
-      "vendor": "INTEL"
-    }
-  ],
+  "storage_devices": [],
   "supported_job_types": {
     "besteffort": false,
     "deploy": true,

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/9e0debfa-9e6a-4c78-809f-7eb7666166dc.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/9e0debfa-9e6a-4c78-809f-7eb7666166dc.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76G8KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:26:f6",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:26:f7",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:4e",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:4f",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:4b:10:00",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/a84f10dd-e99b-424c-b923-ee3c21a642cc.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/a84f10dd-e99b-424c-b923-ee3c21a642cc.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76D5KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:b6",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:b7",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:42",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:43",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:43:d4",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/ab40170d-541e-463d-b2e8-59abab01d14b.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/ab40170d-541e-463d-b2e8-59abab01d14b.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76H2KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:51:96",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:51:97",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:12",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:13",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:43:98",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/affffe50-195e-4f05-ace9-3b1e519f7c8f.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/affffe50-195e-4f05-ace9-3b1e519f7c8f.json
@@ -18,38 +18,45 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:de",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 0,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:df",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:fc",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:fd",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +68,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/b5a84d92-6032-4234-9fcc-d5b488870ee6.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/b5a84d92-6032-4234-9fcc-d5b488870ee6.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76D6KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:44:03:7e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:44:03:7f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:a0",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:a1",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:42:a8",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/b828f7ea-7229-48c2-ba80-b1832f98c4ad.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/b828f7ea-7229-48c2-ba80-b1832f98c4ad.json
@@ -14,66 +14,78 @@
     "name": "PowerEdge R840",
     "serial": "59120D3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "3792 GiB",
     "ram_size": 3792000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "2c:ea:7f:ea:82:34",
+      "management": false,
       "model": "BRCM GbE 4P 5720-t rNDC",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "2c:ea:7f:ea:82:35",
+      "management": false,
       "model": "BRCM GbE 4P 5720-t rNDC",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-3",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "2c:ea:7f:ea:82:36",
+      "management": false,
       "model": "BRCM GbE 4P 5720-t rNDC",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-4",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "2c:ea:7f:ea:82:37",
+      "management": false,
       "model": "BRCM GbE 4P 5720-t rNDC",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.4-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "04:3f:72:ff:9b:de",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 Adpt",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.4-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "04:3f:72:ff:9b:df",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 Adpt",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "InfiniBand.Slot.2-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:73:47:0e",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -85,13 +97,16 @@
   },
   "processor": {
     "cache_l1": 1792000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 28672000,
     "cache_l3": 39424000,
     "clock_speed": 2200000000,
-    "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Platinum 8276 CPU @ 2.20GHz",
+    "instruction_set": null,
+    "model": null,
+    "other_description": "Intel(R) Xeon(R) Platinum 8276 CPU @ 2.20GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/b8af761e-81a3-4f5a-a1d4-d616b3af53fd.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/b8af761e-81a3-4f5a-a1d4-d616b3af53fd.json
@@ -18,38 +18,45 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:37:3e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 0,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:37:3f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d9:48",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d9:49",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +68,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/c44c80f3-ef4b-4115-a80a-0ed93c3b486f.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/c44c80f3-ef4b-4115-a80a-0ed93c3b486f.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76H1KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:5e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:5f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d7:78",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d7:79",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:43:c0",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/c99a8aa1-7202-4ba4-9f8f-b67450a0b461.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/c99a8aa1-7202-4ba4-9f8f-b67450a0b461.json
@@ -18,38 +18,45 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:2d:7e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 0,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:2d:7f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:be",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:bf",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +68,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d042b8ba-5a75-46c4-b89b-9901331d1f20.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d042b8ba-5a75-46c4-b89b-9901331d1f20.json
@@ -18,38 +18,44 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:46:ae",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 0,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:46:af",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:26",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:27",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +67,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {
@@ -77,7 +86,7 @@
       "media_type": "SSD",
       "model": "SSDSC2KB480G8R",
       "rev": "XCV1DL69",
-      "size": 480103980544,
+      "size": 480103981056,
       "vendor": "INTEL"
     }
   ],

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d356feb3-0424-4231-af5f-1132cd600f37.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d356feb3-0424-4231-af5f-1132cd600f37.json
@@ -18,38 +18,44 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:46:56",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 0,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:46:57",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
-      "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:9c",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:9d",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +67,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {
@@ -77,7 +86,7 @@
       "media_type": "SSD",
       "model": "SSDSC2KB480G8R",
       "rev": "XCV1DL69",
-      "size": 480103980544,
+      "size": 480103981056,
       "vendor": "INTEL"
     }
   ],

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d3ca4a4f-2319-4e88-9d63-6c8498f65820.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d3ca4a4f-2319-4e88-9d63-6c8498f65820.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76D2KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:2a:8e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:2a:8f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:da:c2",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:da:c3",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:42:d0",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d3fa821c-e2de-4e5d-af24-648ff710a7c0.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d3fa821c-e2de-4e5d-af24-648ff710a7c0.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:27:06",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:27:07",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:aa",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:ab",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d53dd53a-936e-45ed-b623-6c96e8eb6316.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d53dd53a-936e-45ed-b623-6c96e8eb6316.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R6525",
     "serial": "846ZZC3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",
     "ram_size": 256000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Embedded.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:ef:ed:3c",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Embedded.2-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:ef:ed:3d",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:ce",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:cf",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "InfiniBand.Slot.2-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "0c:42:a1:19:4d:92",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 12288000,
     "cache_l3": 131072000,
     "clock_speed": 2300000000,
     "instruction_set": "x86-64",
-    "model": "AMD EPYC 7352 24-Core Processor",
+    "model": "AMD EPYC",
+    "other_description": "AMD EPYC 7352 24-Core Processor",
     "vendor": "AMD",
-    "version": null
+    "version": "Model 49 Stepping 0"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d6cf10bd-2805-42a0-a14d-3fa1085ef7e1.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d6cf10bd-2805-42a0-a14d-3fa1085ef7e1.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R6525",
     "serial": "847TJD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",
     "ram_size": 256000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Embedded.1-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:d0:a2:9e",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Embedded.2-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "70:b5:e8:d0:a2:9f",
+      "management": false,
       "model": null,
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:b6",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:32:c8:b7",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX5 OCP3 NIC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "InfiniBand.Slot.2-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "0c:42:a1:19:4d:9a",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 12288000,
     "cache_l3": 131072000,
     "clock_speed": 2300000000,
     "instruction_set": "x86-64",
-    "model": "AMD EPYC 7352 24-Core Processor",
+    "model": "AMD EPYC",
+    "other_description": "AMD EPYC 7352 24-Core Processor",
     "vendor": "AMD",
-    "version": null
+    "version": "Model 49 Stepping 0"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d89eb3ee-2c01-4c4f-bb06-f04ef11353bd.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d89eb3ee-2c01-4c4f-bb06-f04ef11353bd.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:46:be",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:46:bf",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:14",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:15",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,26 +69,18 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
-  "storage_devices": [
-    {
-      "device": "Disk.Bay.0:Enclosure.Internal.0-1:NonRAID.Slot.6-1",
-      "humanized_size": "480 GB",
-      "interface": "SATA",
-      "media_type": "SSD",
-      "model": "SSDSC2KB480G8R",
-      "rev": "XCV1DL69",
-      "size": 480103980544,
-      "vendor": "INTEL"
-    }
-  ],
+  "storage_devices": [],
   "supported_job_types": {
     "besteffort": false,
     "deploy": true,

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d8e9821f-99c2-455a-8072-2265c8ba11b0.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d8e9821f-99c2-455a-8072-2265c8ba11b0.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:44:0f:8e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:44:0f:8f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d7:0e",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d7:0f",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/e0477777-88fe-42ec-a686-87e646e02e81.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/e0477777-88fe-42ec-a686-87e646e02e81.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76D0KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:96",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:4f:97",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:48",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:49",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:42:c0",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/e05f677a-d82b-4d41-9de2-751ad3167ccd.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/e05f677a-d82b-4d41-9de2-751ad3167ccd.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76H0KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:37:2e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:37:2f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:50",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:51",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:42:b0",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/e5943f34-96b9-4558-9dfb-1acbc22f2be5.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/e5943f34-96b9-4558-9dfb-1acbc22f2be5.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:46:46",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:46:47",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:a4",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:a5",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/ea794c01-2ae8-4e7a-b1cd-8d64b7610088.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/ea794c01-2ae8-4e7a-b1cd-8d64b7610088.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:2c:1e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:2c:1f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:c0",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:c1",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/ee432c92-78ca-4296-aa58-a10179869b87.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/ee432c92-78ca-4296-aa58-a10179869b87.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:2c:26",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:2c:27",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:da:96",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:da:97",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/f0a70e83-937e-4107-914b-72872c8b741b.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/f0a70e83-937e-4107-914b-72872c8b741b.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:27:1e",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:27:1f",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d7:e0",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d7:e1",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,15 +69,29 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
-  "storage_devices": [],
+  "storage_devices": [
+    {
+      "device": "Disk.Bay.0:Enclosure.Internal.0-1:NonRAID.Slot.6-1",
+      "humanized_size": "480 GB",
+      "interface": "SATA",
+      "media_type": "SSD",
+      "model": "SSDSC2KB480G8R",
+      "rev": "XCV1DL69",
+      "size": 480103980544,
+      "vendor": "INTEL"
+    }
+  ],
   "supported_job_types": {
     "besteffort": false,
     "deploy": true,

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/fd2d912a-01f0-40a8-825f-2c7cd30b56cd.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/fd2d912a-01f0-40a8-825f-2c7cd30b56cd.json
@@ -18,38 +18,46 @@
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:1e:f6",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:43:1e:f7",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:80",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:d8:81",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     }
   ],
@@ -61,13 +69,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/feaecf87-dd11-4aad-8fe8-b8321262f340.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/feaecf87-dd11-4aad-8fe8-b8321262f340.json
@@ -14,50 +14,60 @@
     "name": "PowerEdge R740",
     "serial": "76D7KD3"
   },
+  "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "192 GiB",
     "ram_size": 192000000000
   },
-  "monitoring": {},
+  "monitoring": {
+    "wattmeter": false
+  },
   "network_adapters": [
     {
       "device": "NIC.Integrated.1-1",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:44:0f:66",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Integrated.1-2",
+      "enabled": true,
       "interface": "Ethernet",
       "mac": "b8:ce:f6:44:0f:67",
+      "management": false,
       "model": "MLNX 25GbE 2P ConnectX4LX RNDC",
       "rate": 25000000000,
       "vendor": "Mellanox Technologies"
     },
     {
       "device": "NIC.Slot.7-1",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:86",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "NIC.Slot.7-2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "e4:3d:1a:2d:db:87",
+      "management": false,
       "model": "BRCM GbE 2P 5720-t Adapter",
-      "rate": 0,
       "vendor": "Broadcom Inc. and subsidiaries"
     },
     {
       "device": "InfiniBand.Slot.1-1",
+      "enabled": false,
       "interface": "InfiniBand",
       "mac": "1c:34:da:47:44:68",
+      "management": false,
       "model": null,
-      "rate": null,
       "vendor": "Mellanox Technologies"
     }
   ],
@@ -69,13 +79,16 @@
   },
   "processor": {
     "cache_l1": 1536000,
+    "cache_l1d": null,
+    "cache_l1i": null,
     "cache_l2": 24576000,
     "cache_l3": 36608000,
     "clock_speed": 2400000000,
     "instruction_set": "x86-64",
-    "model": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
+    "model": "Intel Xeon",
+    "other_description": "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz",
     "vendor": "Intel",
-    "version": null
+    "version": "Model 85 Stepping 7"
   },
   "storage_devices": [
     {


### PR DESCRIPTION
Update p3 data using redfish source. Now includes xilinx fpgas, and which interfaces are enabled.