### PR TITLE
New/uc_p3_ssd_intel

### DIFF
--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/6f8e4223-5141-479d-a452-5f4484cdaeb8.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/6f8e4223-5141-479d-a452-5f4484cdaeb8.json
@@ -100,6 +100,26 @@
       "rev": "1.1.1",
       "size": 960197124096,
       "vendor": "Toshiba"
+    },
+    {
+      "device": "Disk.Bay.1:Enclosure.Internal.0-1",
+      "humanized_size": "7681 GB",
+      "interface": "PCIe",
+      "media_type": "SSD",
+      "model": "INTEL SSDPF2KX076TZ",
+      "rev": "JCV10100",
+      "size": 7681501126656,
+      "vendor": "Intel"
+    },
+    {
+      "device": "Disk.Bay.2:Enclosure.Internal.0-1",
+      "humanized_size": "7681 GB",
+      "interface": "PCIe",
+      "media_type": "SSD",
+      "model": "INTEL SSDPF2KX076TZ",
+      "rev": "JCV10100",
+      "size": 7681501126656,
+      "vendor": "Intel"
     }
   ],
   "supported_job_types": {

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/9a3d528e-b7ed-407e-bbf0-4bac74161204.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/9a3d528e-b7ed-407e-bbf0-4bac74161204.json
@@ -100,6 +100,26 @@
       "rev": "1.1.1",
       "size": 960197124096,
       "vendor": "Toshiba"
+    },
+    {
+      "device": "Disk.Bay.1:Enclosure.Internal.0-1",
+      "humanized_size": "7681 GB",
+      "interface": "PCIe",
+      "media_type": "SSD",
+      "model": "INTEL SSDPF2KX076TZ",
+      "rev": "JCV10100",
+      "size": 7681501126656,
+      "vendor": "Intel"
+    },
+    {
+      "device": "Disk.Bay.2:Enclosure.Internal.0-1",
+      "humanized_size": "7681 GB",
+      "interface": "PCIe",
+      "media_type": "SSD",
+      "model": "INTEL SSDPF2KX076TZ",
+      "rev": "JCV10100",
+      "size": 7681501126656,
+      "vendor": "Intel"
     }
   ],
   "supported_job_types": {


### PR DESCRIPTION
add intel SSDs to P3 ndoes at UC

These drives won't appear until two things are done:
1. set the BIOS to allow non-Dell drives: `racadm <auth_stuff> set BIOS.NvmeSettings.BiosNvmeDriver AllDrives`
2. reboot the nodes