### PR TITLE
Fix/redfish_amd

### DIFF
--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/07e0e66c-bc98-4ddb-b7cc-28503633bd1e.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/07e0e66c-bc98-4ddb-b7cc-28503633bd1e.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-12",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "16",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/0c142ce9-1d33-49ff-b00d-9da08929b7f8.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/0c142ce9-1d33-49ff-b00d-9da08929b7f8.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-14",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "18",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/20703057-0f8f-406d-81f0-6301966310e8.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/20703057-0f8f-406d-81f0-6301966310e8.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-07",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "11",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/30c0f814-f6fc-42a7-a504-92f256e5f68a.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/30c0f814-f6fc-42a7-a504-92f256e5f68a.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-10",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "14",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/3a68935d-ba8b-4cb9-976c-26eb77eebe6c.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/3a68935d-ba8b-4cb9-976c-26eb77eebe6c.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-05",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "9",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/54198fad-8320-4543-b806-027fa6a068cb.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/54198fad-8320-4543-b806-027fa6a068cb.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-09",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "13",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/572ccbe4-9855-4bd1-abd7-f6df429cf776.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/572ccbe4-9855-4bd1-abd7-f6df429cf776.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-15",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "19",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/9886caf2-2ce7-4e18-90c9-5ea7b37b68eb.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/9886caf2-2ce7-4e18-90c9-5ea7b37b68eb.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-08",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "12",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/a41ef52c-05d2-49cb-8bbd-352d3bea88ea.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/a41ef52c-05d2-49cb-8bbd-352d3bea88ea.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-16",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "20",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/b20639fb-a589-4a82-9bd9-ca9aed0067da.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/b20639fb-a589-4a82-9bd9-ca9aed0067da.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-13",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "17",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/bf45ad2d-d2cf-4b4c-833f-c4ec2608d45d.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/bf45ad2d-d2cf-4b4c-833f-c4ec2608d45d.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-20",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "24",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/c0065612-5345-43fd-9f09-4185ee1b200e.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/c0065612-5345-43fd-9f09-4185ee1b200e.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-19",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "23",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/da52e94f-aea9-4aa7-b23a-1a8d4e56d2ba.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/da52e94f-aea9-4aa7-b23a-1a8d4e56d2ba.json
@@ -99,7 +99,7 @@
     }
   ],
   "node_name": "c02-18",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "22",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/ddf9c37c-6475-43cf-b09f-4c14282f1f58.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/ddf9c37c-6475-43cf-b09f-4c14282f1f58.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-06",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "10",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/ed53732d-8605-4491-b079-72200a31ebf3.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/ed53732d-8605-4491-b079-72200a31ebf3.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-11",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "15",
     "rack": "BE26"

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/fbe7614f-7236-48da-beab-4793a9addbed.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/fbe7614f-7236-48da-beab-4793a9addbed.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "c02-17",
-  "node_type": "storage_nvme",
+  "node_type": "compute_zen3",
   "placement": {
     "node": "21",
     "rack": "BE26"


### PR DESCRIPTION
Redfish inspector incorrectly set tacc AMD nodes to "storage_nvme".

Proposing "compute_zen3" as node_type.