### PR TITLE
add indyscc nodes

### DIFF
--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/chameleon.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/chameleon.json
@@ -1,0 +1,5 @@
+{
+  "created_at": "Tue, 23 Aug 2022 2:36:00 CST",
+  "type": "cluster",
+  "uid": "chameleon"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/00740990-18da-4105-a8b8-6faed10638ee.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/00740990-18da-4105-a8b8-6faed10638ee.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a443",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "00740990-18da-4105-a8b8-6faed10638ee"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/01ce5c22-6085-4491-ac34-fec7a738f440.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/01ce5c22-6085-4491-ac34-fec7a738f440.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a447",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "01ce5c22-6085-4491-ac34-fec7a738f440"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0343bd05-c7d1-4bd0-b8b2-56d7a300fff9.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0343bd05-c7d1-4bd0-b8b2-56d7a300fff9.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a161",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "0343bd05-c7d1-4bd0-b8b2-56d7a300fff9"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0491901e-db93-46e3-b0da-74737332ecea.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0491901e-db93-46e3-b0da-74737332ecea.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a194",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "0491901e-db93-46e3-b0da-74737332ecea"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/05f04c6b-3975-46d6-b7ce-6ca11877c39d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/05f04c6b-3975-46d6-b7ce-6ca11877c39d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a003",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "05f04c6b-3975-46d6-b7ce-6ca11877c39d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/080183e8-de90-427c-9a7a-56ca6f98282f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/080183e8-de90-427c-9a7a-56ca6f98282f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a163",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "080183e8-de90-427c-9a7a-56ca6f98282f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0843e867-c63b-4ada-b6db-84f8471be05b.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0843e867-c63b-4ada-b6db-84f8471be05b.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a020",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "0843e867-c63b-4ada-b6db-84f8471be05b"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/08bd6fab-a98c-4c7a-960d-c418f28f4b68.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/08bd6fab-a98c-4c7a-960d-c418f28f4b68.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a416",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "08bd6fab-a98c-4c7a-960d-c418f28f4b68"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/08d5426b-b9ec-4b0b-b0df-7039d05a620b.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/08d5426b-b9ec-4b0b-b0df-7039d05a620b.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a015",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "08d5426b-b9ec-4b0b-b0df-7039d05a620b"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/094e42d3-fe4b-4445-a68b-e81367fceb91.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/094e42d3-fe4b-4445-a68b-e81367fceb91.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a469",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "094e42d3-fe4b-4445-a68b-e81367fceb91"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0965cf0e-cf58-4173-85a3-e11f63b5ff17.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0965cf0e-cf58-4173-85a3-e11f63b5ff17.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a003",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "0965cf0e-cf58-4173-85a3-e11f63b5ff17"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/09a51d37-c551-439e-929d-59fb09001061.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/09a51d37-c551-439e-929d-59fb09001061.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a030",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "09a51d37-c551-439e-929d-59fb09001061"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/09cef372-6233-40b7-8b60-74b0877cb767.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/09cef372-6233-40b7-8b60-74b0877cb767.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a206",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "09cef372-6233-40b7-8b60-74b0877cb767"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/09f33ff3-849e-4256-aa1f-e263539d4c8e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/09f33ff3-849e-4256-aa1f-e263539d4c8e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a209",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "09f33ff3-849e-4256-aa1f-e263539d4c8e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0ae8d811-eb09-4af9-a740-7ada70af3932.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0ae8d811-eb09-4af9-a740-7ada70af3932.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a220",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "0ae8d811-eb09-4af9-a740-7ada70af3932"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0c4f1267-dc64-4c9f-8197-29ff2022b816.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0c4f1267-dc64-4c9f-8197-29ff2022b816.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a113",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "0c4f1267-dc64-4c9f-8197-29ff2022b816"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0c61bae2-15da-4acf-abec-f968aa8b6abc.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0c61bae2-15da-4acf-abec-f968aa8b6abc.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a350",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "0c61bae2-15da-4acf-abec-f968aa8b6abc"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0d402781-ff20-4305-a657-e5f80fb09cfa.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0d402781-ff20-4305-a657-e5f80fb09cfa.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a138",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "0d402781-ff20-4305-a657-e5f80fb09cfa"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0ddbfbdd-1f9d-4c2d-82f7-d5da88ec1fbb.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0ddbfbdd-1f9d-4c2d-82f7-d5da88ec1fbb.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a008",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "0ddbfbdd-1f9d-4c2d-82f7-d5da88ec1fbb"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0e075a8b-985e-42fd-adac-3a85a8fbbfd7.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0e075a8b-985e-42fd-adac-3a85a8fbbfd7.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a251",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "0e075a8b-985e-42fd-adac-3a85a8fbbfd7"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0ef00bfb-3d57-4a84-8994-0002f4444126.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0ef00bfb-3d57-4a84-8994-0002f4444126.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a026",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "0ef00bfb-3d57-4a84-8994-0002f4444126"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0f94c37c-99f5-4621-a323-f60843521ce9.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/0f94c37c-99f5-4621-a323-f60843521ce9.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a496",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "0f94c37c-99f5-4621-a323-f60843521ce9"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/11075427-cd71-496a-93ae-04ab32689ff8.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/11075427-cd71-496a-93ae-04ab32689ff8.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a007",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "11075427-cd71-496a-93ae-04ab32689ff8"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/123c547f-676d-48bc-9264-150fa44241f0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/123c547f-676d-48bc-9264-150fa44241f0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a492",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "123c547f-676d-48bc-9264-150fa44241f0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/129b115f-2ff8-449d-81a8-952cbd6932dc.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/129b115f-2ff8-449d-81a8-952cbd6932dc.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a124",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "129b115f-2ff8-449d-81a8-952cbd6932dc"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/135edf74-5c72-4f0c-8105-4c890e28bae7.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/135edf74-5c72-4f0c-8105-4c890e28bae7.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a148",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "135edf74-5c72-4f0c-8105-4c890e28bae7"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/13f9f7b7-d7d4-4302-87cb-25e6bec6d771.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/13f9f7b7-d7d4-4302-87cb-25e6bec6d771.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v1.50 (07/20/2015)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a127",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "13f9f7b7-d7d4-4302-87cb-25e6bec6d771"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/141448a5-a1c6-42ef-977b-b3cabccfabb8.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/141448a5-a1c6-42ef-977b-b3cabccfabb8.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a019",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "141448a5-a1c6-42ef-977b-b3cabccfabb8"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/141b51d3-21b9-4f05-a459-5f635492a245.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/141b51d3-21b9-4f05-a459-5f635492a245.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a230",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "141b51d3-21b9-4f05-a459-5f635492a245"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/143455c4-08f2-4107-b8ee-13b1c730ec19.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/143455c4-08f2-4107-b8ee-13b1c730ec19.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a236",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "143455c4-08f2-4107-b8ee-13b1c730ec19"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/147bb104-1998-4b22-98ba-8c2f35050e64.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/147bb104-1998-4b22-98ba-8c2f35050e64.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a490",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "147bb104-1998-4b22-98ba-8c2f35050e64"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/159c22eb-9c31-4970-98c1-7cd109035e07.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/159c22eb-9c31-4970-98c1-7cd109035e07.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a005",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "159c22eb-9c31-4970-98c1-7cd109035e07"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/16004b21-f292-4de6-acf5-b9b8b9a32417.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/16004b21-f292-4de6-acf5-b9b8b9a32417.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a417",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "16004b21-f292-4de6-acf5-b9b8b9a32417"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1683a409-69e3-4777-b6a7-3bd92553f574.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1683a409-69e3-4777-b6a7-3bd92553f574.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a325",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1683a409-69e3-4777-b6a7-3bd92553f574"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/168c729d-1fb4-4f56-8c09-079de57dbc0c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/168c729d-1fb4-4f56-8c09-079de57dbc0c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a346",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "168c729d-1fb4-4f56-8c09-079de57dbc0c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/16d45b05-e52e-4125-aded-a34340df7ac2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/16d45b05-e52e-4125-aded-a34340df7ac2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a029",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "16d45b05-e52e-4125-aded-a34340df7ac2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/185b2c67-e7bf-43a4-bbe9-d789bbc8cd9a.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/185b2c67-e7bf-43a4-bbe9-d789bbc8cd9a.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a250",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "185b2c67-e7bf-43a4-bbe9-d789bbc8cd9a"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/185e09c4-9969-4395-85c2-c6b69a346a4e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/185e09c4-9969-4395-85c2-c6b69a346a4e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a405",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "185e09c4-9969-4395-85c2-c6b69a346a4e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1a012264-35e4-4061-9267-6f51b507aaa2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1a012264-35e4-4061-9267-6f51b507aaa2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a202",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1a012264-35e4-4061-9267-6f51b507aaa2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1ac7cdc5-b6c1-4ef1-a169-795fc5cf42af.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1ac7cdc5-b6c1-4ef1-a169-795fc5cf42af.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a392",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1ac7cdc5-b6c1-4ef1-a169-795fc5cf42af"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1b495c99-b9d9-4fc9-a82e-c6764c5df59f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1b495c99-b9d9-4fc9-a82e-c6764c5df59f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a058",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1b495c99-b9d9-4fc9-a82e-c6764c5df59f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1bc7df07-a93d-4ceb-977e-8489924ebb50.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1bc7df07-a93d-4ceb-977e-8489924ebb50.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a204",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1bc7df07-a93d-4ceb-977e-8489924ebb50"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1d59b0f9-365a-4f82-afcf-a2acc2fe6c30.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1d59b0f9-365a-4f82-afcf-a2acc2fe6c30.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a458",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1d59b0f9-365a-4f82-afcf-a2acc2fe6c30"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1d789652-70de-4d79-810f-36b2d2aa7f89.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1d789652-70de-4d79-810f-36b2d2aa7f89.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a395",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1d789652-70de-4d79-810f-36b2d2aa7f89"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1f406448-70ba-44dc-aaac-a03a9609bba2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1f406448-70ba-44dc-aaac-a03a9609bba2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v1.50 (07/20/2015)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a349",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1f406448-70ba-44dc-aaac-a03a9609bba2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1f506982-a921-4aea-8430-5271ca9aeeb9.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1f506982-a921-4aea-8430-5271ca9aeeb9.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a433",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1f506982-a921-4aea-8430-5271ca9aeeb9"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1f51d284-c3fb-4035-ac14-7d0e7bf00e5e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1f51d284-c3fb-4035-ac14-7d0e7bf00e5e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a348",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1f51d284-c3fb-4035-ac14-7d0e7bf00e5e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1f9d8c7b-c8be-471f-b235-655fc5668b51.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1f9d8c7b-c8be-471f-b235-655fc5668b51.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a081",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1f9d8c7b-c8be-471f-b235-655fc5668b51"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1faecc15-e5da-4606-9c29-37a913a6b736.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1faecc15-e5da-4606-9c29-37a913a6b736.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a060",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1faecc15-e5da-4606-9c29-37a913a6b736"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1fd132c6-99bb-4f5e-ba8f-71987d3cfd8c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/1fd132c6-99bb-4f5e-ba8f-71987d3cfd8c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a165",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1fd132c6-99bb-4f5e-ba8f-71987d3cfd8c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/20395df4-b559-4c62-afba-b13a51a79ef4.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/20395df4-b559-4c62-afba-b13a51a79ef4.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a004",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "20395df4-b559-4c62-afba-b13a51a79ef4"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2088b210-92b9-4824-8818-d72ac59f4fe1.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2088b210-92b9-4824-8818-d72ac59f4fe1.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a484",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "2088b210-92b9-4824-8818-d72ac59f4fe1"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/21113108-f38e-4954-8ae3-be8951f12642.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/21113108-f38e-4954-8ae3-be8951f12642.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a107",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "21113108-f38e-4954-8ae3-be8951f12642"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/22928dc9-5b81-4ca9-824e-dd7f022cc92b.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/22928dc9-5b81-4ca9-824e-dd7f022cc92b.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a471",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "22928dc9-5b81-4ca9-824e-dd7f022cc92b"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/22c5ba8a-3d92-4e8d-a496-4633946ab516.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/22c5ba8a-3d92-4e8d-a496-4633946ab516.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a464",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "22c5ba8a-3d92-4e8d-a496-4633946ab516"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/231c5b43-9420-4d0c-921b-56ee0718f8d8.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/231c5b43-9420-4d0c-921b-56ee0718f8d8.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a155",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "231c5b43-9420-4d0c-921b-56ee0718f8d8"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/23993916-bedb-4a12-a6a2-7c151079b42c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/23993916-bedb-4a12-a6a2-7c151079b42c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a170",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "23993916-bedb-4a12-a6a2-7c151079b42c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/23e78e69-6cad-4a16-b1a2-707bf208d3ba.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/23e78e69-6cad-4a16-b1a2-707bf208d3ba.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a174",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "23e78e69-6cad-4a16-b1a2-707bf208d3ba"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/244e325d-3277-45a9-a63f-344f1c5a2120.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/244e325d-3277-45a9-a63f-344f1c5a2120.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a034",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "244e325d-3277-45a9-a63f-344f1c5a2120"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/259d28f8-4f9f-4949-9e2d-9af947b7b875.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/259d28f8-4f9f-4949-9e2d-9af947b7b875.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a110",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "259d28f8-4f9f-4949-9e2d-9af947b7b875"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/268ce5eb-f7ec-48ea-9cbd-a56ac2e693c1.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/268ce5eb-f7ec-48ea-9cbd-a56ac2e693c1.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a493",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "268ce5eb-f7ec-48ea-9cbd-a56ac2e693c1"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/277f230b-4b89-43e6-b2bf-8b9b261df90b.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/277f230b-4b89-43e6-b2bf-8b9b261df90b.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a454",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "277f230b-4b89-43e6-b2bf-8b9b261df90b"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/27f16b57-853a-414f-8b94-8fefd14fa17d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/27f16b57-853a-414f-8b94-8fefd14fa17d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a037",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "27f16b57-853a-414f-8b94-8fefd14fa17d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/286d5df5-ef89-4404-8980-4f54358dd457.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/286d5df5-ef89-4404-8980-4f54358dd457.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a255",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "286d5df5-ef89-4404-8980-4f54358dd457"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/28bfb90f-95db-4ac5-bf0e-0393b0f7e3f4.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/28bfb90f-95db-4ac5-bf0e-0393b0f7e3f4.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a372",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "28bfb90f-95db-4ac5-bf0e-0393b0f7e3f4"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/29356df4-2ad6-465a-9457-1709a9fd28d0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/29356df4-2ad6-465a-9457-1709a9fd28d0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a175",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "29356df4-2ad6-465a-9457-1709a9fd28d0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/29ec7c88-960f-4674-ac70-2ea8860b7709.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/29ec7c88-960f-4674-ac70-2ea8860b7709.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a427",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "29ec7c88-960f-4674-ac70-2ea8860b7709"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2a94129b-a67f-49dc-b982-5f16c7d78e20.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2a94129b-a67f-49dc-b982-5f16c7d78e20.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a328",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "2a94129b-a67f-49dc-b982-5f16c7d78e20"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2ac2d40c-3c76-484d-983e-7e7070fd8cb1.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2ac2d40c-3c76-484d-983e-7e7070fd8cb1.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a505",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "2ac2d40c-3c76-484d-983e-7e7070fd8cb1"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2c6d9ea5-1e91-40ef-826b-b9244b31e3a8.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2c6d9ea5-1e91-40ef-826b-b9244b31e3a8.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a481",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "2c6d9ea5-1e91-40ef-826b-b9244b31e3a8"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2dd1882f-5b51-4cab-a2b3-8449cf15d261.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2dd1882f-5b51-4cab-a2b3-8449cf15d261.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a446",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "2dd1882f-5b51-4cab-a2b3-8449cf15d261"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2e34c210-77cd-4fa5-a48a-a61a6107fcff.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2e34c210-77cd-4fa5-a48a-a61a6107fcff.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a419",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "2e34c210-77cd-4fa5-a48a-a61a6107fcff"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2ed46d86-bedb-4d72-9b84-7a02062a9236.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/2ed46d86-bedb-4d72-9b84-7a02062a9236.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a135",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "2ed46d86-bedb-4d72-9b84-7a02062a9236"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/316ce585-1aeb-4a00-bc3d-03f0c0b33eec.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/316ce585-1aeb-4a00-bc3d-03f0c0b33eec.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a094",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "316ce585-1aeb-4a00-bc3d-03f0c0b33eec"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/32110adc-9b51-4a50-ac86-aca469272530.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/32110adc-9b51-4a50-ac86-aca469272530.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a211",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "32110adc-9b51-4a50-ac86-aca469272530"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3220f95e-5187-454f-9f50-1dfe22c13f0e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3220f95e-5187-454f-9f50-1dfe22c13f0e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a358",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "3220f95e-5187-454f-9f50-1dfe22c13f0e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/32abb85f-ae29-4123-96e9-15848f812656.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/32abb85f-ae29-4123-96e9-15848f812656.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a189",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "32abb85f-ae29-4123-96e9-15848f812656"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/33aa2a1b-b18e-48f6-84f0-45d578b94af0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/33aa2a1b-b18e-48f6-84f0-45d578b94af0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a139",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "33aa2a1b-b18e-48f6-84f0-45d578b94af0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/33afa2b9-0d15-4d10-937d-408dbab09940.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/33afa2b9-0d15-4d10-937d-408dbab09940.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v1.50 (07/20/2015)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a479",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "33afa2b9-0d15-4d10-937d-408dbab09940"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/33dd0e32-bb17-404b-92a8-4f2c135bfa75.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/33dd0e32-bb17-404b-92a8-4f2c135bfa75.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a091",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "33dd0e32-bb17-404b-92a8-4f2c135bfa75"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/33f71dc1-a77e-47d4-b37f-98927968a40d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/33f71dc1-a77e-47d4-b37f-98927968a40d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a086",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "33f71dc1-a77e-47d4-b37f-98927968a40d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/358e2761-432e-485a-9316-ec5f20011339.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/358e2761-432e-485a-9316-ec5f20011339.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a001",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "358e2761-432e-485a-9316-ec5f20011339"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/35fe7f37-ddff-4baf-bd4a-43048fee4abc.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/35fe7f37-ddff-4baf-bd4a-43048fee4abc.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a421",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "35fe7f37-ddff-4baf-bd4a-43048fee4abc"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/36189031-e915-4a06-b3e8-aabb7f8f127b.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/36189031-e915-4a06-b3e8-aabb7f8f127b.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a424",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "36189031-e915-4a06-b3e8-aabb7f8f127b"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/37df60ba-9028-4c8c-a5c1-b6889df5d754.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/37df60ba-9028-4c8c-a5c1-b6889df5d754.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a108",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "37df60ba-9028-4c8c-a5c1-b6889df5d754"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3886a895-12fa-4d5a-878a-def66adc4da7.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3886a895-12fa-4d5a-878a-def66adc4da7.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a208",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "3886a895-12fa-4d5a-878a-def66adc4da7"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/389f4ef8-5627-4809-b1af-d4b200494474.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/389f4ef8-5627-4809-b1af-d4b200494474.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a368",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "389f4ef8-5627-4809-b1af-d4b200494474"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3912365b-2489-4cbf-becc-6d40e29c8521.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3912365b-2489-4cbf-becc-6d40e29c8521.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a409",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "3912365b-2489-4cbf-becc-6d40e29c8521"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/395727a7-ef16-4cb1-b1e1-93f4433b6c73.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/395727a7-ef16-4cb1-b1e1-93f4433b6c73.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a011",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "395727a7-ef16-4cb1-b1e1-93f4433b6c73"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/39f62a27-a829-4542-aeb5-2538d43ad36f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/39f62a27-a829-4542-aeb5-2538d43ad36f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 09/12/2016"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a415",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "39f62a27-a829-4542-aeb5-2538d43ad36f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3afa2cff-6acd-4dbe-9edf-e906671fe16e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3afa2cff-6acd-4dbe-9edf-e906671fe16e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a333",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "3afa2cff-6acd-4dbe-9edf-e906671fe16e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3c0b92f8-d857-40dc-b0d6-0096287a0e9c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3c0b92f8-d857-40dc-b0d6-0096287a0e9c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a396",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "3c0b92f8-d857-40dc-b0d6-0096287a0e9c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3d0ee3be-2e68-4cc8-a6d2-15bd428248a4.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3d0ee3be-2e68-4cc8-a6d2-15bd428248a4.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a370",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "3d0ee3be-2e68-4cc8-a6d2-15bd428248a4"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3dca25cf-cde4-4128-a2c8-7535f1a9f851.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3dca25cf-cde4-4128-a2c8-7535f1a9f851.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a262",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "3dca25cf-cde4-4128-a2c8-7535f1a9f851"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3e1fcd01-1968-4d2d-89b6-cfd28787e52a.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3e1fcd01-1968-4d2d-89b6-cfd28787e52a.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a005",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "3e1fcd01-1968-4d2d-89b6-cfd28787e52a"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3ed3e998-f55e-4a08-906d-6d19c643dad7.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3ed3e998-f55e-4a08-906d-6d19c643dad7.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a217",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "3ed3e998-f55e-4a08-906d-6d19c643dad7"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3f10065e-6662-4f97-b37c-29763d145f94.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/3f10065e-6662-4f97-b37c-29763d145f94.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a016",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "3f10065e-6662-4f97-b37c-29763d145f94"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/40ecf455-d47f-4e4e-aa14-665249bbc490.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/40ecf455-d47f-4e4e-aa14-665249bbc490.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a483",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "40ecf455-d47f-4e4e-aa14-665249bbc490"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/410ecd9c-c0f0-4fe6-8705-7e56f2c66744.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/410ecd9c-c0f0-4fe6-8705-7e56f2c66744.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a404",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "410ecd9c-c0f0-4fe6-8705-7e56f2c66744"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/41dff020-6ab8-4d32-a7de-161e9028bac7.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/41dff020-6ab8-4d32-a7de-161e9028bac7.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a352",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "41dff020-6ab8-4d32-a7de-161e9028bac7"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/41f2732b-7296-409a-87a4-9b9b7e326b05.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/41f2732b-7296-409a-87a4-9b9b7e326b05.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a200",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "41f2732b-7296-409a-87a4-9b9b7e326b05"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4222f9b3-44da-4e03-8357-6d9489262e66.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4222f9b3-44da-4e03-8357-6d9489262e66.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a442",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4222f9b3-44da-4e03-8357-6d9489262e66"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/42d85ce3-f06a-4ff0-b29f-71cbeccdd20f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/42d85ce3-f06a-4ff0-b29f-71cbeccdd20f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a465",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "42d85ce3-f06a-4ff0-b29f-71cbeccdd20f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/442123e7-6d95-45ce-b84b-9c0f308146c9.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/442123e7-6d95-45ce-b84b-9c0f308146c9.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a364",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "442123e7-6d95-45ce-b84b-9c0f308146c9"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4469f298-02aa-49cb-9f80-a3df9966f5d9.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4469f298-02aa-49cb-9f80-a3df9966f5d9.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a399",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4469f298-02aa-49cb-9f80-a3df9966f5d9"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/44e465fb-9b90-4e90-bfa4-bb64d1b15991.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/44e465fb-9b90-4e90-bfa4-bb64d1b15991.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a512",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "44e465fb-9b90-4e90-bfa4-bb64d1b15991"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/45df66b9-7023-46bd-a183-57afb0d71d44.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/45df66b9-7023-46bd-a183-57afb0d71d44.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a312",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "45df66b9-7023-46bd-a183-57afb0d71d44"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4624620d-f399-402d-9d8a-e6bddef0c053.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4624620d-f399-402d-9d8a-e6bddef0c053.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a218",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4624620d-f399-402d-9d8a-e6bddef0c053"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/46b483c9-e124-434a-8558-cbbc4d2b62b4.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/46b483c9-e124-434a-8558-cbbc4d2b62b4.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a331",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "46b483c9-e124-434a-8558-cbbc4d2b62b4"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/46d943e3-f67a-4858-ba4a-b55e8d6f622e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/46d943e3-f67a-4858-ba4a-b55e8d6f622e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a363",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "46d943e3-f67a-4858-ba4a-b55e8d6f622e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/477b1a20-70e4-4ae8-b97f-57cc09ad7aff.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/477b1a20-70e4-4ae8-b97f-57cc09ad7aff.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a167",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "477b1a20-70e4-4ae8-b97f-57cc09ad7aff"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/47a84f17-3be9-4d99-8418-c6dd58f5bc68.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/47a84f17-3be9-4d99-8418-c6dd58f5bc68.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a400",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "47a84f17-3be9-4d99-8418-c6dd58f5bc68"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/47ce0aa3-d234-49bd-ae6f-9db3a4263ee3.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/47ce0aa3-d234-49bd-ae6f-9db3a4263ee3.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a444",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "47ce0aa3-d234-49bd-ae6f-9db3a4263ee3"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/47dad857-58b4-4d1a-b820-2f42359d3491.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/47dad857-58b4-4d1a-b820-2f42359d3491.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a205",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "47dad857-58b4-4d1a-b820-2f42359d3491"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4922f586-3783-4f01-9d98-c309eb0e3ff3.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4922f586-3783-4f01-9d98-c309eb0e3ff3.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a498",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4922f586-3783-4f01-9d98-c309eb0e3ff3"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/49a33475-e8b6-4bfa-8732-1206af47e65c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/49a33475-e8b6-4bfa-8732-1206af47e65c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a257",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "49a33475-e8b6-4bfa-8732-1206af47e65c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/49cfc1ed-edcf-49d0-821c-4ba1c20752ff.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/49cfc1ed-edcf-49d0-821c-4ba1c20752ff.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a177",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "49cfc1ed-edcf-49d0-821c-4ba1c20752ff"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/49ea0b2c-9e1e-4627-867c-536ae81d5294.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/49ea0b2c-9e1e-4627-867c-536ae81d5294.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a357",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "49ea0b2c-9e1e-4627-867c-536ae81d5294"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/49f4a5c4-244e-4ef7-9497-93fa370495a7.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/49f4a5c4-244e-4ef7-9497-93fa370495a7.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a313",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "49f4a5c4-244e-4ef7-9497-93fa370495a7"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4a1889a8-f0cd-42b3-951f-1a130b7c85b7.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4a1889a8-f0cd-42b3-951f-1a130b7c85b7.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a015",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4a1889a8-f0cd-42b3-951f-1a130b7c85b7"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4a6e1337-309e-4586-9269-28898414e32e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4a6e1337-309e-4586-9269-28898414e32e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a233",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4a6e1337-309e-4586-9269-28898414e32e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4ac0b78d-cd9f-4336-8924-8f7012dfeea6.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4ac0b78d-cd9f-4336-8924-8f7012dfeea6.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a120",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4ac0b78d-cd9f-4336-8924-8f7012dfeea6"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4b109163-0552-4026-b8e2-d5597ac7f10c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4b109163-0552-4026-b8e2-d5597ac7f10c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a246",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4b109163-0552-4026-b8e2-d5597ac7f10c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4cd40fff-48ff-4aaa-ac33-14ecc2213715.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4cd40fff-48ff-4aaa-ac33-14ecc2213715.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a084",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4cd40fff-48ff-4aaa-ac33-14ecc2213715"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4d32f873-f0de-4b55-9de0-fe5bf719ca44.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4d32f873-f0de-4b55-9de0-fe5bf719ca44.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a059",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4d32f873-f0de-4b55-9de0-fe5bf719ca44"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4dbf76ad-173f-4238-9c5d-736359e23f23.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4dbf76ad-173f-4238-9c5d-736359e23f23.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a341",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4dbf76ad-173f-4238-9c5d-736359e23f23"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4e8890d4-a246-43f7-8de9-53254d2fad65.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4e8890d4-a246-43f7-8de9-53254d2fad65.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a334",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4e8890d4-a246-43f7-8de9-53254d2fad65"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4fdb6bed-5e76-4df8-b757-f31c29f17ecf.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/4fdb6bed-5e76-4df8-b757-f31c29f17ecf.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a361",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4fdb6bed-5e76-4df8-b757-f31c29f17ecf"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/52ee4f3b-17af-4fc9-bedb-c5057acc39f2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/52ee4f3b-17af-4fc9-bedb-c5057acc39f2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "224 GiB",
+    "ram_size": 224000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a004",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "52ee4f3b-17af-4fc9-bedb-c5057acc39f2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/52fd8c6c-c0bc-4547-b28d-04a95714ea9f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/52fd8c6c-c0bc-4547-b28d-04a95714ea9f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 09/12/2016"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a061",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "52fd8c6c-c0bc-4547-b28d-04a95714ea9f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/533d4be6-7af7-4eb3-85ad-2daabd58a9ae.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/533d4be6-7af7-4eb3-85ad-2daabd58a9ae.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a062",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "533d4be6-7af7-4eb3-85ad-2daabd58a9ae"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/538fc604-50e9-4e4c-815e-e010125eab60.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/538fc604-50e9-4e4c-815e-e010125eab60.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a041",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "538fc604-50e9-4e4c-815e-e010125eab60"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/539a6e51-e51f-44f9-849b-c2d3c7cbe9d8.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/539a6e51-e51f-44f9-849b-c2d3c7cbe9d8.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a451",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "539a6e51-e51f-44f9-849b-c2d3c7cbe9d8"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5426d1a2-be17-48f1-af9a-2bd8d7304d60.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5426d1a2-be17-48f1-af9a-2bd8d7304d60.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a057",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5426d1a2-be17-48f1-af9a-2bd8d7304d60"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/54415a4a-3513-4ee9-8e48-33736f40dfcb.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/54415a4a-3513-4ee9-8e48-33736f40dfcb.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a239",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "54415a4a-3513-4ee9-8e48-33736f40dfcb"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/54a51785-3126-465c-8d89-5c401272300d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/54a51785-3126-465c-8d89-5c401272300d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a149",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "54a51785-3126-465c-8d89-5c401272300d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/54d12418-501b-414d-be58-a758f105dfa8.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/54d12418-501b-414d-be58-a758f105dfa8.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a196",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "54d12418-501b-414d-be58-a758f105dfa8"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/55b552ab-0345-4b6c-8689-0cce784e9f81.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/55b552ab-0345-4b6c-8689-0cce784e9f81.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a452",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "55b552ab-0345-4b6c-8689-0cce784e9f81"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/561340e4-b3cb-467a-b13b-80fbe9951d8a.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/561340e4-b3cb-467a-b13b-80fbe9951d8a.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a191",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "561340e4-b3cb-467a-b13b-80fbe9951d8a"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/564b3c21-f589-43d6-87e2-e85b10cd9767.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/564b3c21-f589-43d6-87e2-e85b10cd9767.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a048",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "564b3c21-f589-43d6-87e2-e85b10cd9767"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/565ab146-9e83-4add-a77f-c57fb177cae9.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/565ab146-9e83-4add-a77f-c57fb177cae9.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a088",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "565ab146-9e83-4add-a77f-c57fb177cae9"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/56a24f6b-5e27-4b2b-9360-0b90ffc2864a.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/56a24f6b-5e27-4b2b-9360-0b90ffc2864a.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a054",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "56a24f6b-5e27-4b2b-9360-0b90ffc2864a"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/56b0e5af-2ed1-4987-bbf1-850eb639b4c0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/56b0e5af-2ed1-4987-bbf1-850eb639b4c0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a168",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "56b0e5af-2ed1-4987-bbf1-850eb639b4c0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/57b75742-98c7-48eb-9d19-f7ce0669ebca.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/57b75742-98c7-48eb-9d19-f7ce0669ebca.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a345",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "57b75742-98c7-48eb-9d19-f7ce0669ebca"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/58e2c6cd-a60b-4b07-8c20-e4ea75241b1f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/58e2c6cd-a60b-4b07-8c20-e4ea75241b1f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a216",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "58e2c6cd-a60b-4b07-8c20-e4ea75241b1f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/597ce057-4252-46a0-b7b7-422800368293.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/597ce057-4252-46a0-b7b7-422800368293.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a052",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "597ce057-4252-46a0-b7b7-422800368293"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/59964156-863f-4511-a86d-98cd0c9a5c1d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/59964156-863f-4511-a86d-98cd0c9a5c1d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a044",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "59964156-863f-4511-a86d-98cd0c9a5c1d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/59be8e33-333d-467e-abcd-1498ff25f23c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/59be8e33-333d-467e-abcd-1498ff25f23c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a118",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "59be8e33-333d-467e-abcd-1498ff25f23c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5a6ddc8d-4f0f-418d-931e-bc5c5a230fd7.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5a6ddc8d-4f0f-418d-931e-bc5c5a230fd7.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a109",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5a6ddc8d-4f0f-418d-931e-bc5c5a230fd7"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5b131ccf-678d-4fae-ab4e-900b5278ac03.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5b131ccf-678d-4fae-ab4e-900b5278ac03.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a013",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5b131ccf-678d-4fae-ab4e-900b5278ac03"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5bdd92ff-e134-4942-87bb-3222c25f2414.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5bdd92ff-e134-4942-87bb-3222c25f2414.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a123",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5bdd92ff-e134-4942-87bb-3222c25f2414"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5d1231dc-ea61-4ecf-9f4d-c44f76d27a27.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5d1231dc-ea61-4ecf-9f4d-c44f76d27a27.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a207",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5d1231dc-ea61-4ecf-9f4d-c44f76d27a27"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5d5a895f-24d2-4e43-9994-0e2da5dcf9a4.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5d5a895f-24d2-4e43-9994-0e2da5dcf9a4.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a011",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5d5a895f-24d2-4e43-9994-0e2da5dcf9a4"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5dce6809-c88d-498f-8f62-be5ebf29ac10.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5dce6809-c88d-498f-8f62-be5ebf29ac10.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a002",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5dce6809-c88d-498f-8f62-be5ebf29ac10"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5e6566a7-1bcc-4d6d-a912-28cecdd6f413.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5e6566a7-1bcc-4d6d-a912-28cecdd6f413.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a040",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5e6566a7-1bcc-4d6d-a912-28cecdd6f413"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5f55eb8c-ec43-4ddb-87eb-c78146d910d5.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5f55eb8c-ec43-4ddb-87eb-c78146d910d5.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a432",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5f55eb8c-ec43-4ddb-87eb-c78146d910d5"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5f7bdc78-3bbd-4191-a2a6-954d9927dcf7.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5f7bdc78-3bbd-4191-a2a6-954d9927dcf7.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a232",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5f7bdc78-3bbd-4191-a2a6-954d9927dcf7"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5f7c5c5e-fb29-47b1-8682-22ceb444de86.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5f7c5c5e-fb29-47b1-8682-22ceb444de86.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a179",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5f7c5c5e-fb29-47b1-8682-22ceb444de86"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5fde550c-addb-40c8-8e1b-3420a926ae6d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/5fde550c-addb-40c8-8e1b-3420a926ae6d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a183",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5fde550c-addb-40c8-8e1b-3420a926ae6d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6087301d-aa11-45c3-ae9b-9f9beae8183e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6087301d-aa11-45c3-ae9b-9f9beae8183e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a012",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6087301d-aa11-45c3-ae9b-9f9beae8183e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6093dd70-025c-42c9-b90b-20b79367dd2f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6093dd70-025c-42c9-b90b-20b79367dd2f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a321",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6093dd70-025c-42c9-b90b-20b79367dd2f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/60bf437e-ed48-4120-b3d0-2c9fafea52c3.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/60bf437e-ed48-4120-b3d0-2c9fafea52c3.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a393",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "60bf437e-ed48-4120-b3d0-2c9fafea52c3"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/60fcaa7e-0087-4f35-bbe4-38397758883b.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/60fcaa7e-0087-4f35-bbe4-38397758883b.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a071",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "60fcaa7e-0087-4f35-bbe4-38397758883b"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/61271dd8-1d3a-4ce5-93b1-d9036f218f8a.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/61271dd8-1d3a-4ce5-93b1-d9036f218f8a.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a461",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "61271dd8-1d3a-4ce5-93b1-d9036f218f8a"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/637361f7-f1c9-4e0b-91b4-a8f9e4609a82.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/637361f7-f1c9-4e0b-91b4-a8f9e4609a82.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a383",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "637361f7-f1c9-4e0b-91b4-a8f9e4609a82"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/653adc63-1c8d-4cc1-9871-9df7e01898b4.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/653adc63-1c8d-4cc1-9871-9df7e01898b4.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a445",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "653adc63-1c8d-4cc1-9871-9df7e01898b4"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6603ea1a-53d4-4c81-a723-a2963004bc75.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6603ea1a-53d4-4c81-a723-a2963004bc75.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a180",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6603ea1a-53d4-4c81-a723-a2963004bc75"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6746535c-ca30-424e-80dc-f8c1d221ca68.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6746535c-ca30-424e-80dc-f8c1d221ca68.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a385",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6746535c-ca30-424e-80dc-f8c1d221ca68"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/674bf49a-0e39-4b9e-a8d7-4883012e8ded.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/674bf49a-0e39-4b9e-a8d7-4883012e8ded.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a140",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "674bf49a-0e39-4b9e-a8d7-4883012e8ded"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/67c7b6fe-05ec-40a8-bc4e-6ee6e7d3f092.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/67c7b6fe-05ec-40a8-bc4e-6ee6e7d3f092.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a069",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "67c7b6fe-05ec-40a8-bc4e-6ee6e7d3f092"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6828b070-1710-4f5e-a09e-6b1f32ee774f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6828b070-1710-4f5e-a09e-6b1f32ee774f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a014",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6828b070-1710-4f5e-a09e-6b1f32ee774f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/693b3062-6224-4953-a326-2a0f209c6f62.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/693b3062-6224-4953-a326-2a0f209c6f62.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a327",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "693b3062-6224-4953-a326-2a0f209c6f62"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6942be37-ae6f-4797-aaef-44cebba04f54.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6942be37-ae6f-4797-aaef-44cebba04f54.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a457",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6942be37-ae6f-4797-aaef-44cebba04f54"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/69c89ae2-3f15-4e89-8dc1-136a9b852cd2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/69c89ae2-3f15-4e89-8dc1-136a9b852cd2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a428",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "69c89ae2-3f15-4e89-8dc1-136a9b852cd2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/69fc1056-5b30-46cd-8e3c-ce0d5f6035e8.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/69fc1056-5b30-46cd-8e3c-ce0d5f6035e8.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a133",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "69fc1056-5b30-46cd-8e3c-ce0d5f6035e8"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6a1b0038-72bd-4b4f-9821-9ab01ef43465.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6a1b0038-72bd-4b4f-9821-9ab01ef43465.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a437",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6a1b0038-72bd-4b4f-9821-9ab01ef43465"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6a365ca3-b010-4c4f-ac39-0e2d1c0f9818.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6a365ca3-b010-4c4f-ac39-0e2d1c0f9818.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a132",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6a365ca3-b010-4c4f-ac39-0e2d1c0f9818"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6adb18bb-bc12-4e64-8e70-0932346edab2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6adb18bb-bc12-4e64-8e70-0932346edab2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a153",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6adb18bb-bc12-4e64-8e70-0932346edab2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6ae816e6-d32a-479f-b1b2-34a70e54b97f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6ae816e6-d32a-479f-b1b2-34a70e54b97f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a515",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6ae816e6-d32a-479f-b1b2-34a70e54b97f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6c8542b2-8e38-41ab-a4f8-703d7728734c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6c8542b2-8e38-41ab-a4f8-703d7728734c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a234",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6c8542b2-8e38-41ab-a4f8-703d7728734c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6c8b8d98-edd4-4436-91e6-fe492606387d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6c8b8d98-edd4-4436-91e6-fe492606387d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a347",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6c8b8d98-edd4-4436-91e6-fe492606387d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6c99f2f6-ecd7-4457-8f65-33e58318db0c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6c99f2f6-ecd7-4457-8f65-33e58318db0c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a076",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6c99f2f6-ecd7-4457-8f65-33e58318db0c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6cd6a42d-2997-4850-8b87-d6bd402b403e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6cd6a42d-2997-4850-8b87-d6bd402b403e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 09/12/2016"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a336",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6cd6a42d-2997-4850-8b87-d6bd402b403e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6d6bc598-e3bb-4136-b038-5928401cb48f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6d6bc598-e3bb-4136-b038-5928401cb48f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a198",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6d6bc598-e3bb-4136-b038-5928401cb48f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6de34d1a-5102-47a6-a100-3cf131467f0d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6de34d1a-5102-47a6-a100-3cf131467f0d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a455",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6de34d1a-5102-47a6-a100-3cf131467f0d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6e43f549-cbf9-41c8-8b6d-87b569b6ab7a.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6e43f549-cbf9-41c8-8b6d-87b569b6ab7a.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v1.50 (07/20/2015)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a318",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6e43f549-cbf9-41c8-8b6d-87b569b6ab7a"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6e9ac53a-8dea-4578-acb5-1d6a51ec285e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6e9ac53a-8dea-4578-acb5-1d6a51ec285e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v1.50 (07/20/2015)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a023",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6e9ac53a-8dea-4578-acb5-1d6a51ec285e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6ec42397-19d9-48ce-8774-1b489b1e7e45.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6ec42397-19d9-48ce-8774-1b489b1e7e45.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a356",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6ec42397-19d9-48ce-8774-1b489b1e7e45"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6ecc2d6e-e446-4f30-a2f4-9ccc0050264e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/6ecc2d6e-e446-4f30-a2f4-9ccc0050264e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a414",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6ecc2d6e-e446-4f30-a2f4-9ccc0050264e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/70eb2671-07be-4d3d-bb8c-7ddf0e6ded08.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/70eb2671-07be-4d3d-bb8c-7ddf0e6ded08.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a513",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "70eb2671-07be-4d3d-bb8c-7ddf0e6ded08"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/70f20949-dfd9-43d1-952a-c5a9922a2a82.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/70f20949-dfd9-43d1-952a-c5a9922a2a82.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a093",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "70f20949-dfd9-43d1-952a-c5a9922a2a82"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/71c72060-6ee9-41f0-9806-d39c1af1a747.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/71c72060-6ee9-41f0-9806-d39c1af1a747.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a033",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "71c72060-6ee9-41f0-9806-d39c1af1a747"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/71db8cd7-c57c-42e4-a540-0f817fcc5602.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/71db8cd7-c57c-42e4-a540-0f817fcc5602.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a050",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "71db8cd7-c57c-42e4-a540-0f817fcc5602"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7322fc2f-53d6-42e7-a4b8-85bdf9e32fc5.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7322fc2f-53d6-42e7-a4b8-85bdf9e32fc5.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a223",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7322fc2f-53d6-42e7-a4b8-85bdf9e32fc5"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/733a0b64-6f65-4e01-8311-24f5699d9229.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/733a0b64-6f65-4e01-8311-24f5699d9229.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a104",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "733a0b64-6f65-4e01-8311-24f5699d9229"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/73623963-fc5b-4e98-948d-62c09adacb45.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/73623963-fc5b-4e98-948d-62c09adacb45.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a159",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "73623963-fc5b-4e98-948d-62c09adacb45"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7391e91d-0ba1-4145-bdad-5eea89035ce1.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7391e91d-0ba1-4145-bdad-5eea89035ce1.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a156",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7391e91d-0ba1-4145-bdad-5eea89035ce1"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/754ace68-f836-4c0d-8ae0-3decc7a73293.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/754ace68-f836-4c0d-8ae0-3decc7a73293.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v1.50 (07/20/2015)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a142",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "754ace68-f836-4c0d-8ae0-3decc7a73293"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/75d2fbe4-0c7b-439d-821a-b3e0a8430f76.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/75d2fbe4-0c7b-439d-821a-b3e0a8430f76.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a254",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "75d2fbe4-0c7b-439d-821a-b3e0a8430f76"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/75d81f47-b1a4-4c58-acf9-9fc3ad0c7325.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/75d81f47-b1a4-4c58-acf9-9fc3ad0c7325.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a362",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "75d81f47-b1a4-4c58-acf9-9fc3ad0c7325"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/761247ae-7f68-4b77-87f5-2740d98a25b2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/761247ae-7f68-4b77-87f5-2740d98a25b2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a042",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "761247ae-7f68-4b77-87f5-2740d98a25b2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7642349d-8e02-48f6-9d38-c83b0a0cfc52.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7642349d-8e02-48f6-9d38-c83b0a0cfc52.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v1.50 (07/20/2015)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a386",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7642349d-8e02-48f6-9d38-c83b0a0cfc52"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/764fc5ce-ae4f-4cd2-a9c7-ad1d7bea72ba.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/764fc5ce-ae4f-4cd2-a9c7-ad1d7bea72ba.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a376",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "764fc5ce-ae4f-4cd2-a9c7-ad1d7bea72ba"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/767aabc4-463d-442d-a3d4-cdd1a58e4f43.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/767aabc4-463d-442d-a3d4-cdd1a58e4f43.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a203",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "767aabc4-463d-442d-a3d4-cdd1a58e4f43"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/768448a6-3c98-4f02-a2b6-f40fd2e3461e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/768448a6-3c98-4f02-a2b6-f40fd2e3461e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a423",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "768448a6-3c98-4f02-a2b6-f40fd2e3461e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/77b88bb3-d0d8-4ae3-aaea-5160ab8f22c2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/77b88bb3-d0d8-4ae3-aaea-5160ab8f22c2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a426",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "77b88bb3-d0d8-4ae3-aaea-5160ab8f22c2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7803bdc7-b34f-408f-bcc2-e136a5090cce.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7803bdc7-b34f-408f-bcc2-e136a5090cce.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a495",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7803bdc7-b34f-408f-bcc2-e136a5090cce"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/783b6799-2922-43ee-98c8-73edf734f7aa.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/783b6799-2922-43ee-98c8-73edf734f7aa.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a462",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "783b6799-2922-43ee-98c8-73edf734f7aa"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/79781521-6d14-47b1-9257-fdcc2113965d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/79781521-6d14-47b1-9257-fdcc2113965d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a488",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "79781521-6d14-47b1-9257-fdcc2113965d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7a1314c4-1d5e-4cc5-888b-ae619ac4bd93.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7a1314c4-1d5e-4cc5-888b-ae619ac4bd93.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a360",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7a1314c4-1d5e-4cc5-888b-ae619ac4bd93"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7ab29b81-604c-4d29-92ac-2f7a59c3a895.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7ab29b81-604c-4d29-92ac-2f7a59c3a895.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a072",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7ab29b81-604c-4d29-92ac-2f7a59c3a895"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7bfc50d7-9ed6-4969-a536-b9908041555c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7bfc50d7-9ed6-4969-a536-b9908041555c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a188",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7bfc50d7-9ed6-4969-a536-b9908041555c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7c8083cb-59db-416f-a649-8b69e21793a1.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7c8083cb-59db-416f-a649-8b69e21793a1.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a243",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7c8083cb-59db-416f-a649-8b69e21793a1"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7cc990c2-4ab6-4144-8d31-c067ee7bd814.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7cc990c2-4ab6-4144-8d31-c067ee7bd814.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a418",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7cc990c2-4ab6-4144-8d31-c067ee7bd814"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7cdb3e64-0636-4f55-a34d-03e65a9a2b93.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7cdb3e64-0636-4f55-a34d-03e65a9a2b93.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a182",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7cdb3e64-0636-4f55-a34d-03e65a9a2b93"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7e6bb525-07cb-4d97-84e5-3bacbd3b6107.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7e6bb525-07cb-4d97-84e5-3bacbd3b6107.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a510",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7e6bb525-07cb-4d97-84e5-3bacbd3b6107"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7ee6b526-d830-4f03-90ab-3644359e4be2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7ee6b526-d830-4f03-90ab-3644359e4be2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a136",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7ee6b526-d830-4f03-90ab-3644359e4be2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7f0c5ef6-daae-40bc-8f9c-ea022598021b.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7f0c5ef6-daae-40bc-8f9c-ea022598021b.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a253",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7f0c5ef6-daae-40bc-8f9c-ea022598021b"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7f429aad-ddc5-4c28-adf8-078ff50994a2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7f429aad-ddc5-4c28-adf8-078ff50994a2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a070",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7f429aad-ddc5-4c28-adf8-078ff50994a2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7f904bd1-73c2-42d0-8e3d-dafdb0a2fe56.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/7f904bd1-73c2-42d0-8e3d-dafdb0a2fe56.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a144",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7f904bd1-73c2-42d0-8e3d-dafdb0a2fe56"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8056bdf6-a3c4-44cc-a3dc-072fcff209b5.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8056bdf6-a3c4-44cc-a3dc-072fcff209b5.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a342",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8056bdf6-a3c4-44cc-a3dc-072fcff209b5"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/818889e6-1883-4590-af43-f99128338bb0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/818889e6-1883-4590-af43-f99128338bb0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a308",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "818889e6-1883-4590-af43-f99128338bb0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/81a8160d-008f-4f0e-bfc7-52d370a4e1f1.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/81a8160d-008f-4f0e-bfc7-52d370a4e1f1.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a111",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "81a8160d-008f-4f0e-bfc7-52d370a4e1f1"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/82344992-0e54-4028-a5d0-d5d381945d10.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/82344992-0e54-4028-a5d0-d5d381945d10.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a077",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "82344992-0e54-4028-a5d0-d5d381945d10"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/828412a4-6b33-4391-bb79-82e14f05d06a.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/828412a4-6b33-4391-bb79-82e14f05d06a.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a162",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "828412a4-6b33-4391-bb79-82e14f05d06a"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/833eed9d-2d22-4667-839d-b198747680c0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/833eed9d-2d22-4667-839d-b198747680c0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a440",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "833eed9d-2d22-4667-839d-b198747680c0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/83d1b80d-8c5c-40a3-80bc-8cc9972ee87f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/83d1b80d-8c5c-40a3-80bc-8cc9972ee87f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a000",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "83d1b80d-8c5c-40a3-80bc-8cc9972ee87f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/85b01111-bd57-434c-a8bd-e7ae6a856943.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/85b01111-bd57-434c-a8bd-e7ae6a856943.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a460",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "85b01111-bd57-434c-a8bd-e7ae6a856943"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/85dd2c97-a476-4cce-b9e5-7d233ce8aa62.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/85dd2c97-a476-4cce-b9e5-7d233ce8aa62.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a377",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "85dd2c97-a476-4cce-b9e5-7d233ce8aa62"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/86008308-9737-459e-b6ba-264a83cadedf.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/86008308-9737-459e-b6ba-264a83cadedf.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.00 (12/27/2015)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a403",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "86008308-9737-459e-b6ba-264a83cadedf"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8824a345-d49c-4ee9-9aa4-d6f81907c805.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8824a345-d49c-4ee9-9aa4-d6f81907c805.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a332",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8824a345-d49c-4ee9-9aa4-d6f81907c805"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8829543b-f93e-42cd-a983-03d276f98682.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8829543b-f93e-42cd-a983-03d276f98682.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a064",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8829543b-f93e-42cd-a983-03d276f98682"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/88f0b13b-fe74-4733-b417-d82292b0e3ad.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/88f0b13b-fe74-4733-b417-d82292b0e3ad.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a178",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "88f0b13b-fe74-4733-b417-d82292b0e3ad"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8964cb9a-1ba9-4c01-8d6a-6496c16164f7.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8964cb9a-1ba9-4c01-8d6a-6496c16164f7.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a125",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8964cb9a-1ba9-4c01-8d6a-6496c16164f7"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/89870a78-a9c5-4000-8ef1-00026f88a439.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/89870a78-a9c5-4000-8ef1-00026f88a439.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a181",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "89870a78-a9c5-4000-8ef1-00026f88a439"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8a951e4a-48aa-4b89-8e31-d8bfa30474bb.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8a951e4a-48aa-4b89-8e31-d8bfa30474bb.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a186",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8a951e4a-48aa-4b89-8e31-d8bfa30474bb"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8b25640e-bb11-406b-a0a0-4070f603e390.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8b25640e-bb11-406b-a0a0-4070f603e390.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a150",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8b25640e-bb11-406b-a0a0-4070f603e390"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8b8c6dac-4071-4d80-9650-c99b72f29237.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8b8c6dac-4071-4d80-9650-c99b72f29237.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 09/12/2016"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a503",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8b8c6dac-4071-4d80-9650-c99b72f29237"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8cf288ba-4d59-4bdf-b37b-17298b61d1be.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8cf288ba-4d59-4bdf-b37b-17298b61d1be.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a402",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8cf288ba-4d59-4bdf-b37b-17298b61d1be"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8d55511f-8215-4f60-bd2f-655ad1589d13.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8d55511f-8215-4f60-bd2f-655ad1589d13.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a476",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8d55511f-8215-4f60-bd2f-655ad1589d13"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8f59e814-d55f-4e0a-a0bf-8f7d6ca3c9d3.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8f59e814-d55f-4e0a-a0bf-8f7d6ca3c9d3.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a314",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8f59e814-d55f-4e0a-a0bf-8f7d6ca3c9d3"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8f867cc3-eef0-4f94-a10e-601e43d7a9c2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8f867cc3-eef0-4f94-a10e-601e43d7a9c2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a025",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8f867cc3-eef0-4f94-a10e-601e43d7a9c2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8f90e98a-5434-4032-9f5f-32239c934051.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8f90e98a-5434-4032-9f5f-32239c934051.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a509",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8f90e98a-5434-4032-9f5f-32239c934051"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8febc66c-292e-40bd-aa52-9e740162bd11.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/8febc66c-292e-40bd-aa52-9e740162bd11.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a009",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8febc66c-292e-40bd-aa52-9e740162bd11"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/909b9b2d-b50e-4335-b691-b24128f9b23a.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/909b9b2d-b50e-4335-b691-b24128f9b23a.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a009",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "909b9b2d-b50e-4335-b691-b24128f9b23a"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/911841c0-ece3-4e02-a02c-609b6b9574b9.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/911841c0-ece3-4e02-a02c-609b6b9574b9.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a115",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "911841c0-ece3-4e02-a02c-609b6b9574b9"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/91ba4845-9867-4f9c-8ea5-4b8ee02557fb.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/91ba4845-9867-4f9c-8ea5-4b8ee02557fb.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a201",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "91ba4845-9867-4f9c-8ea5-4b8ee02557fb"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/92f605bb-a941-4b06-9fd1-08419b637a58.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/92f605bb-a941-4b06-9fd1-08419b637a58.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a477",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "92f605bb-a941-4b06-9fd1-08419b637a58"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/93371b75-7779-42d2-9ad2-89eda40229a1.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/93371b75-7779-42d2-9ad2-89eda40229a1.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a219",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "93371b75-7779-42d2-9ad2-89eda40229a1"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/93bce736-ef80-4e30-98aa-efbf12830ec8.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/93bce736-ef80-4e30-98aa-efbf12830ec8.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a261",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "93bce736-ef80-4e30-98aa-efbf12830ec8"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/93c4584d-272c-4563-87a1-56b72afeb63f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/93c4584d-272c-4563-87a1-56b72afeb63f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a319",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "93c4584d-272c-4563-87a1-56b72afeb63f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/94935d4e-f423-4a5d-aab6-f1206b3f0d71.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/94935d4e-f423-4a5d-aab6-f1206b3f0d71.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a101",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "94935d4e-f423-4a5d-aab6-f1206b3f0d71"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/96716802-3af4-4bbe-a185-f6f684004a69.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/96716802-3af4-4bbe-a185-f6f684004a69.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a438",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "96716802-3af4-4bbe-a185-f6f684004a69"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/96722d5f-f73b-41be-a078-ce50fe1a0993.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/96722d5f-f73b-41be-a078-ce50fe1a0993.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a195",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "96722d5f-f73b-41be-a078-ce50fe1a0993"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9738bceb-784a-438c-9ae3-efbb0569b6f5.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9738bceb-784a-438c-9ae3-efbb0569b6f5.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a018",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "9738bceb-784a-438c-9ae3-efbb0569b6f5"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/97cc8630-f519-475e-880d-fb8b346a0007.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/97cc8630-f519-475e-880d-fb8b346a0007.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a056",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "97cc8630-f519-475e-880d-fb8b346a0007"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/97ef108b-ea32-412a-b073-1525203de78c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/97ef108b-ea32-412a-b073-1525203de78c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a436",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "97ef108b-ea32-412a-b073-1525203de78c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/986397ab-625f-413b-9d43-3431fbf8938d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/986397ab-625f-413b-9d43-3431fbf8938d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a466",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "986397ab-625f-413b-9d43-3431fbf8938d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/989f982c-bda8-4821-9720-e06a037079c8.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/989f982c-bda8-4821-9720-e06a037079c8.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a097",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "989f982c-bda8-4821-9720-e06a037079c8"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/99123f90-38df-4d7c-8f3a-993c325d0d93.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/99123f90-38df-4d7c-8f3a-993c325d0d93.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a032",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "99123f90-38df-4d7c-8f3a-993c325d0d93"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/99153345-660b-446e-8430-9e4463b14379.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/99153345-660b-446e-8430-9e4463b14379.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a425",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "99153345-660b-446e-8430-9e4463b14379"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/998584ab-22ce-403e-aab6-813bef8ee010.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/998584ab-22ce-403e-aab6-813bef8ee010.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a467",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "998584ab-22ce-403e-aab6-813bef8ee010"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9989a1f1-6214-4bb3-8ba7-1d3f100dcb41.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9989a1f1-6214-4bb3-8ba7-1d3f100dcb41.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a073",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "9989a1f1-6214-4bb3-8ba7-1d3f100dcb41"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/99d0cad8-70d3-44b4-aa51-0361cbf74987.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/99d0cad8-70d3-44b4-aa51-0361cbf74987.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a378",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "99d0cad8-70d3-44b4-aa51-0361cbf74987"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9a6ef2b1-f5c5-4944-894d-0da17f6d18f6.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9a6ef2b1-f5c5-4944-894d-0da17f6d18f6.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a099",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "9a6ef2b1-f5c5-4944-894d-0da17f6d18f6"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9abed633-6994-4dc9-b85a-8c8c20cb5d20.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9abed633-6994-4dc9-b85a-8c8c20cb5d20.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a095",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "9abed633-6994-4dc9-b85a-8c8c20cb5d20"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9af0784a-c093-43b8-9f85-ad0f6f22b3c0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9af0784a-c093-43b8-9f85-ad0f6f22b3c0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a501",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "9af0784a-c093-43b8-9f85-ad0f6f22b3c0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9b1015e9-19d5-47fb-953d-4b54190dc45f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9b1015e9-19d5-47fb-953d-4b54190dc45f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a221",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "9b1015e9-19d5-47fb-953d-4b54190dc45f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9dd0582f-73c2-4c6a-9457-0381a862e226.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/9dd0582f-73c2-4c6a-9457-0381a862e226.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a335",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "9dd0582f-73c2-4c6a-9457-0381a862e226"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a05418ea-7efc-41c9-845b-b6fa064545ad.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a05418ea-7efc-41c9-845b-b6fa064545ad.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a017",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a05418ea-7efc-41c9-845b-b6fa064545ad"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a1b0635a-cf9e-4010-95de-d19526ca6de6.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a1b0635a-cf9e-4010-95de-d19526ca6de6.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a105",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a1b0635a-cf9e-4010-95de-d19526ca6de6"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a2264b2a-b8bd-4dd8-aa81-de5a57d41b91.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a2264b2a-b8bd-4dd8-aa81-de5a57d41b91.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a367",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a2264b2a-b8bd-4dd8-aa81-de5a57d41b91"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a255a673-b48f-4559-a076-f1c9ad302540.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a255a673-b48f-4559-a076-f1c9ad302540.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a103",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a255a673-b48f-4559-a076-f1c9ad302540"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a29b02c4-4fff-4aab-bbc2-6675c2fb7e46.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a29b02c4-4fff-4aab-bbc2-6675c2fb7e46.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a468",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a29b02c4-4fff-4aab-bbc2-6675c2fb7e46"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a40932d7-694e-402c-b7f4-3e9c2129fa0a.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a40932d7-694e-402c-b7f4-3e9c2129fa0a.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v1.50 (07/20/2015)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a215",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a40932d7-694e-402c-b7f4-3e9c2129fa0a"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a48e1333-3462-42e0-be98-16089f02f91f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a48e1333-3462-42e0-be98-16089f02f91f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a330",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a48e1333-3462-42e0-be98-16089f02f91f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a6959b8d-6b46-49f3-b821-76ee7a91c761.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a6959b8d-6b46-49f3-b821-76ee7a91c761.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a066",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a6959b8d-6b46-49f3-b821-76ee7a91c761"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a6fcf864-4994-47d3-8d62-24930bfe0e94.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a6fcf864-4994-47d3-8d62-24930bfe0e94.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a000",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a6fcf864-4994-47d3-8d62-24930bfe0e94"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a7cf3860-b576-4cab-9611-1ed729c20171.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a7cf3860-b576-4cab-9611-1ed729c20171.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a389",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a7cf3860-b576-4cab-9611-1ed729c20171"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a911043c-1e22-414b-b61d-6aac9a2f71f8.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a911043c-1e22-414b-b61d-6aac9a2f71f8.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a045",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a911043c-1e22-414b-b61d-6aac9a2f71f8"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a9f3df82-3869-4d8e-9992-08e4d3b24b01.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/a9f3df82-3869-4d8e-9992-08e4d3b24b01.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a001",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a9f3df82-3869-4d8e-9992-08e4d3b24b01"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/aace49a7-560d-4587-bfb3-69267c08a7d3.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/aace49a7-560d-4587-bfb3-69267c08a7d3.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a260",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "aace49a7-560d-4587-bfb3-69267c08a7d3"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ac1737f0-3d2d-4337-9c3d-96028f3326ff.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ac1737f0-3d2d-4337-9c3d-96028f3326ff.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a212",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ac1737f0-3d2d-4337-9c3d-96028f3326ff"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ace27651-a0af-42e9-8698-c76932de35be.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ace27651-a0af-42e9-8698-c76932de35be.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a475",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ace27651-a0af-42e9-8698-c76932de35be"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b020ae4b-d907-4616-9ec3-11fa3bc2dc98.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b020ae4b-d907-4616-9ec3-11fa3bc2dc98.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a102",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b020ae4b-d907-4616-9ec3-11fa3bc2dc98"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b05d7f8f-9202-4504-9592-2c67e556e6e9.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b05d7f8f-9202-4504-9592-2c67e556e6e9.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a090",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b05d7f8f-9202-4504-9592-2c67e556e6e9"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b08919c5-9646-46d7-9032-0bb27e9f95fb.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b08919c5-9646-46d7-9032-0bb27e9f95fb.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a010",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b08919c5-9646-46d7-9032-0bb27e9f95fb"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b0bc628e-2528-4c90-8c5d-257d056477d1.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b0bc628e-2528-4c90-8c5d-257d056477d1.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a134",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b0bc628e-2528-4c90-8c5d-257d056477d1"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b0eb64fc-3c90-4e91-9d81-fdb46f51761e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b0eb64fc-3c90-4e91-9d81-fdb46f51761e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a079",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b0eb64fc-3c90-4e91-9d81-fdb46f51761e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b1c69fa5-295b-4c9f-82db-89e71cc7e2ef.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b1c69fa5-295b-4c9f-82db-89e71cc7e2ef.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.40 (02/17/2017)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a024",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b1c69fa5-295b-4c9f-82db-89e71cc7e2ef"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b222c667-eae1-4539-8354-aaf2fd39b766.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b222c667-eae1-4539-8354-aaf2fd39b766.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a371",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b222c667-eae1-4539-8354-aaf2fd39b766"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b26508fb-a70d-49b1-8cf8-7812b12187ac.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b26508fb-a70d-49b1-8cf8-7812b12187ac.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a244",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b26508fb-a70d-49b1-8cf8-7812b12187ac"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b32d295d-ad7e-4ab6-a54a-7219345cc089.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b32d295d-ad7e-4ab6-a54a-7219345cc089.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a406",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b32d295d-ad7e-4ab6-a54a-7219345cc089"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b635c7a5-da92-4d97-a7cb-d3264bff5277.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b635c7a5-da92-4d97-a7cb-d3264bff5277.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 09/12/2016"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a122",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b635c7a5-da92-4d97-a7cb-d3264bff5277"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b6774c60-9ca0-4998-950d-a439664cb062.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b6774c60-9ca0-4998-950d-a439664cb062.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a098",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b6774c60-9ca0-4998-950d-a439664cb062"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b6a12d04-b15b-496f-8638-f24c5df8f477.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b6a12d04-b15b-496f-8638-f24c5df8f477.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a411",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b6a12d04-b15b-496f-8638-f24c5df8f477"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b70a1123-1b1b-4019-83e3-ddcca78bbff0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b70a1123-1b1b-4019-83e3-ddcca78bbff0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a192",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b70a1123-1b1b-4019-83e3-ddcca78bbff0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b7409970-90fd-4d3a-adcd-6550895391ee.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b7409970-90fd-4d3a-adcd-6550895391ee.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a338",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b7409970-90fd-4d3a-adcd-6550895391ee"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b756abed-f9a1-4a9f-9a94-8d7604ec80a8.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b756abed-f9a1-4a9f-9a94-8d7604ec80a8.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a117",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b756abed-f9a1-4a9f-9a94-8d7604ec80a8"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b7664874-9108-461a-bfd8-44268a8d5e8e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b7664874-9108-461a-bfd8-44268a8d5e8e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a225",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b7664874-9108-461a-bfd8-44268a8d5e8e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b8b3d1c8-6e4a-4207-a6a3-bb6eca00f638.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b8b3d1c8-6e4a-4207-a6a3-bb6eca00f638.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a434",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b8b3d1c8-6e4a-4207-a6a3-bb6eca00f638"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b8c809f5-d07f-48ea-b074-3c4feb201011.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b8c809f5-d07f-48ea-b074-3c4feb201011.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a176",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b8c809f5-d07f-48ea-b074-3c4feb201011"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b8fe1090-1802-49e3-9978-2a5d2708dba0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b8fe1090-1802-49e3-9978-2a5d2708dba0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a013",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b8fe1090-1802-49e3-9978-2a5d2708dba0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b90ab6e4-ec5b-4968-bcae-c56a347e4495.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b90ab6e4-ec5b-4968-bcae-c56a347e4495.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a147",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b90ab6e4-ec5b-4968-bcae-c56a347e4495"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b931b6bf-d13b-40bc-81d7-b70d592b68da.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b931b6bf-d13b-40bc-81d7-b70d592b68da.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a166",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b931b6bf-d13b-40bc-81d7-b70d592b68da"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b9a1d661-aab3-4c4b-945b-3f612c51bf4c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b9a1d661-aab3-4c4b-945b-3f612c51bf4c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a063",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b9a1d661-aab3-4c4b-945b-3f612c51bf4c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b9ec6d3b-ab9e-4151-8094-c6958c744027.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/b9ec6d3b-ab9e-4151-8094-c6958c744027.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a035",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b9ec6d3b-ab9e-4151-8094-c6958c744027"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ba9dd4d4-af01-48c6-88b6-9533b868e080.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ba9dd4d4-af01-48c6-88b6-9533b868e080.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a507",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ba9dd4d4-af01-48c6-88b6-9533b868e080"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bc080ba9-0012-4270-98e1-08191036c9bd.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bc080ba9-0012-4270-98e1-08191036c9bd.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a080",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "bc080ba9-0012-4270-98e1-08191036c9bd"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bc29c8b4-6c1d-44a2-bc5d-9f63d037340a.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bc29c8b4-6c1d-44a2-bc5d-9f63d037340a.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a184",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "bc29c8b4-6c1d-44a2-bc5d-9f63d037340a"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bd14636d-d33b-48f0-b5ba-b6c632752631.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bd14636d-d33b-48f0-b5ba-b6c632752631.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a224",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "bd14636d-d33b-48f0-b5ba-b6c632752631"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bd6b4c33-f944-4d2c-8a14-3935bede00dc.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bd6b4c33-f944-4d2c-8a14-3935bede00dc.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a169",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "bd6b4c33-f944-4d2c-8a14-3935bede00dc"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bd7f9ef9-3a5a-4366-98fc-e93d6cf333eb.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bd7f9ef9-3a5a-4366-98fc-e93d6cf333eb.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a229",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "bd7f9ef9-3a5a-4366-98fc-e93d6cf333eb"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bde1d851-4276-405d-83be-55334a00637d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bde1d851-4276-405d-83be-55334a00637d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a511",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "bde1d851-4276-405d-83be-55334a00637d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/be918b75-7637-41b1-8929-39d674ec65cc.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/be918b75-7637-41b1-8929-39d674ec65cc.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a407",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "be918b75-7637-41b1-8929-39d674ec65cc"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/beda9a08-982e-4c52-ae8a-390697aabe14.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/beda9a08-982e-4c52-ae8a-390697aabe14.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a126",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "beda9a08-982e-4c52-ae8a-390697aabe14"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bffca16c-40ec-4aea-b6d2-4e8e0747387b.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/bffca16c-40ec-4aea-b6d2-4e8e0747387b.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a006",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "bffca16c-40ec-4aea-b6d2-4e8e0747387b"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c0552778-af93-4451-b826-d362d03ba833.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c0552778-af93-4451-b826-d362d03ba833.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a012",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c0552778-af93-4451-b826-d362d03ba833"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c0aa5d69-685f-4ff6-84ef-1787d243a868.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c0aa5d69-685f-4ff6-84ef-1787d243a868.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a320",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c0aa5d69-685f-4ff6-84ef-1787d243a868"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c1d85002-0cb9-4faf-9daf-e93e3fc43cda.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c1d85002-0cb9-4faf-9daf-e93e3fc43cda.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a055",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c1d85002-0cb9-4faf-9daf-e93e3fc43cda"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c1def319-2928-4478-a3e7-6eafa832dc21.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c1def319-2928-4478-a3e7-6eafa832dc21.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a435",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c1def319-2928-4478-a3e7-6eafa832dc21"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c278d8f5-e78c-430c-a59b-6f122bd8abb0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c278d8f5-e78c-430c-a59b-6f122bd8abb0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a082",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c278d8f5-e78c-430c-a59b-6f122bd8abb0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c2b2df3b-001f-4ebc-a31f-d1f544d705ac.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c2b2df3b-001f-4ebc-a31f-d1f544d705ac.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a197",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c2b2df3b-001f-4ebc-a31f-d1f544d705ac"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c2e03930-9564-4106-a076-d1aea13037f0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c2e03930-9564-4106-a076-d1aea13037f0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a470",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c2e03930-9564-4106-a076-d1aea13037f0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c344a0c4-53cc-42da-9af4-c85afaeb38af.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c344a0c4-53cc-42da-9af4-c85afaeb38af.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a439",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c344a0c4-53cc-42da-9af4-c85afaeb38af"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c36e8abc-fde0-4125-b5f4-2c6084821b7e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c36e8abc-fde0-4125-b5f4-2c6084821b7e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a114",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c36e8abc-fde0-4125-b5f4-2c6084821b7e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c3a84c57-813b-4605-bee4-2abd20e266d0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c3a84c57-813b-4605-bee4-2abd20e266d0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a051",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c3a84c57-813b-4605-bee4-2abd20e266d0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c4247dc9-7c2a-455b-b977-0cf32fdee8a8.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c4247dc9-7c2a-455b-b977-0cf32fdee8a8.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a339",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c4247dc9-7c2a-455b-b977-0cf32fdee8a8"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c4dbddfb-2a30-45c2-9f0a-2556b174d585.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c4dbddfb-2a30-45c2-9f0a-2556b174d585.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a157",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c4dbddfb-2a30-45c2-9f0a-2556b174d585"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c60be674-9e89-4ab5-bb42-5e50a838b568.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c60be674-9e89-4ab5-bb42-5e50a838b568.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a116",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c60be674-9e89-4ab5-bb42-5e50a838b568"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c615156d-8e1c-47f5-a42c-858562c3b685.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c615156d-8e1c-47f5-a42c-858562c3b685.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a263",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c615156d-8e1c-47f5-a42c-858562c3b685"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c616b3ae-0e47-46e7-92c3-e7b593a26f36.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c616b3ae-0e47-46e7-92c3-e7b593a26f36.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a129",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c616b3ae-0e47-46e7-92c3-e7b593a26f36"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c6b7c964-6bf4-4dd2-8b8c-01a81aa2802d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c6b7c964-6bf4-4dd2-8b8c-01a81aa2802d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a456",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c6b7c964-6bf4-4dd2-8b8c-01a81aa2802d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c79a8d86-a4c2-4033-9c15-e79ee88d8331.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c79a8d86-a4c2-4033-9c15-e79ee88d8331.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a473",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c79a8d86-a4c2-4033-9c15-e79ee88d8331"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c8da29b7-7c76-49e7-bbbe-8404dde205f2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c8da29b7-7c76-49e7-bbbe-8404dde205f2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a247",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c8da29b7-7c76-49e7-bbbe-8404dde205f2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c9549412-7ff5-4170-a202-8816800a4d7b.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c9549412-7ff5-4170-a202-8816800a4d7b.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a472",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c9549412-7ff5-4170-a202-8816800a4d7b"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c9fdc0f5-27b7-4e73-8d06-2735453b874d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/c9fdc0f5-27b7-4e73-8d06-2735453b874d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a237",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c9fdc0f5-27b7-4e73-8d06-2735453b874d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/cad94ec0-b9cc-4ecf-b5ee-59378d7baaca.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/cad94ec0-b9cc-4ecf-b5ee-59378d7baaca.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a039",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "cad94ec0-b9cc-4ecf-b5ee-59378d7baaca"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/caf7799e-6474-498a-b49c-b79cab0bd96c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/caf7799e-6474-498a-b49c-b79cab0bd96c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a340",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "caf7799e-6474-498a-b49c-b79cab0bd96c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/cb8db581-8ea5-46a1-9934-44572a367d91.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/cb8db581-8ea5-46a1-9934-44572a367d91.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a049",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "cb8db581-8ea5-46a1-9934-44572a367d91"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ce9d97c7-84f4-402e-8c27-b6fafe896d22.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ce9d97c7-84f4-402e-8c27-b6fafe896d22.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a380",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ce9d97c7-84f4-402e-8c27-b6fafe896d22"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d1573285-0f4d-4af8-9567-b9d81e9d6790.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d1573285-0f4d-4af8-9567-b9d81e9d6790.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a514",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d1573285-0f4d-4af8-9567-b9d81e9d6790"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d1748232-6c53-46a8-a5dd-5bda946d3db7.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d1748232-6c53-46a8-a5dd-5bda946d3db7.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a500",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d1748232-6c53-46a8-a5dd-5bda946d3db7"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d19aeacc-f68e-4d19-adc7-d443e3f68d3a.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d19aeacc-f68e-4d19-adc7-d443e3f68d3a.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v1.50 (07/20/2015)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a375",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d19aeacc-f68e-4d19-adc7-d443e3f68d3a"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d1afd082-b139-44e7-b5c9-cd5f41647bf1.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d1afd082-b139-44e7-b5c9-cd5f41647bf1.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a448",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d1afd082-b139-44e7-b5c9-cd5f41647bf1"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d2abc2ca-642e-4def-b741-1435c9ea511d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d2abc2ca-642e-4def-b741-1435c9ea511d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a410",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d2abc2ca-642e-4def-b741-1435c9ea511d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d36fdd3a-cc4e-46d8-99b2-da28903e3187.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d36fdd3a-cc4e-46d8-99b2-da28903e3187.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a309",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d36fdd3a-cc4e-46d8-99b2-da28903e3187"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d419cbde-fe4b-498c-8ad5-4ac191f79e31.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d419cbde-fe4b-498c-8ad5-4ac191f79e31.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a128",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d419cbde-fe4b-498c-8ad5-4ac191f79e31"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d44d9970-e30c-41cb-a273-9ff61d0a052d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d44d9970-e30c-41cb-a273-9ff61d0a052d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a311",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d44d9970-e30c-41cb-a273-9ff61d0a052d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d5395dff-f180-4824-8bd9-9cd911fa662f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d5395dff-f180-4824-8bd9-9cd911fa662f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a047",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d5395dff-f180-4824-8bd9-9cd911fa662f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d57eee25-cd69-4081-bc9a-937097fb7e21.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d57eee25-cd69-4081-bc9a-937097fb7e21.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a007",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d57eee25-cd69-4081-bc9a-937097fb7e21"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d62bfa6a-64de-4d78-9db3-582c8177bebf.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d62bfa6a-64de-4d78-9db3-582c8177bebf.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a359",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d62bfa6a-64de-4d78-9db3-582c8177bebf"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d731aa2f-06ee-48c8-8763-14fc17d17697.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d731aa2f-06ee-48c8-8763-14fc17d17697.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a365",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d731aa2f-06ee-48c8-8763-14fc17d17697"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d73d5f3e-2c9f-4988-91fb-cac574c4557c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d73d5f3e-2c9f-4988-91fb-cac574c4557c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a187",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d73d5f3e-2c9f-4988-91fb-cac574c4557c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d7bee03a-4900-497c-9b15-28080f754ac0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d7bee03a-4900-497c-9b15-28080f754ac0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a249",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d7bee03a-4900-497c-9b15-28080f754ac0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d8299b0a-66ef-45ee-aaba-8632edf4a05f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d8299b0a-66ef-45ee-aaba-8632edf4a05f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a486",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d8299b0a-66ef-45ee-aaba-8632edf4a05f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d84a06c6-8dd8-4183-a66a-63c7d778b8db.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d84a06c6-8dd8-4183-a66a-63c7d778b8db.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a459",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d84a06c6-8dd8-4183-a66a-63c7d778b8db"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d8b82549-57e5-4b04-a51b-f346b74b27c3.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/d8b82549-57e5-4b04-a51b-f346b74b27c3.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a315",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d8b82549-57e5-4b04-a51b-f346b74b27c3"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/db6699d7-6a5d-4934-894c-7a147cf028e1.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/db6699d7-6a5d-4934-894c-7a147cf028e1.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a323",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "db6699d7-6a5d-4934-894c-7a147cf028e1"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/dc15f05c-8323-4ccc-a51c-bc0e2a809a34.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/dc15f05c-8323-4ccc-a51c-bc0e2a809a34.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a474",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "dc15f05c-8323-4ccc-a51c-bc0e2a809a34"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/dc3033a2-5eba-4813-9976-3e68cab74967.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/dc3033a2-5eba-4813-9976-3e68cab74967.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a494",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "dc3033a2-5eba-4813-9976-3e68cab74967"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/dc5560e7-06b6-4d98-8dbb-cbcf968b2edc.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/dc5560e7-06b6-4d98-8dbb-cbcf968b2edc.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a441",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "dc5560e7-06b6-4d98-8dbb-cbcf968b2edc"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/dca0982e-94c5-4729-a6e6-f20e79ff2e34.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/dca0982e-94c5-4729-a6e6-f20e79ff2e34.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a408",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "dca0982e-94c5-4729-a6e6-f20e79ff2e34"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/de991f9c-ce38-4e42-9af6-2dc9cf8fb83d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/de991f9c-ce38-4e42-9af6-2dc9cf8fb83d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a480",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "de991f9c-ce38-4e42-9af6-2dc9cf8fb83d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e0530c18-62cb-498c-bd1a-bb590cfecce9.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e0530c18-62cb-498c-bd1a-bb590cfecce9.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a240",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e0530c18-62cb-498c-bd1a-bb590cfecce9"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e10de960-07b3-4208-95af-4d8189447144.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e10de960-07b3-4208-95af-4d8189447144.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a199",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e10de960-07b3-4208-95af-4d8189447144"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e19faab2-a9ee-4f1e-80e1-b9b374eb23f3.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e19faab2-a9ee-4f1e-80e1-b9b374eb23f3.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a351",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e19faab2-a9ee-4f1e-80e1-b9b374eb23f3"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e36572bf-dca7-42c7-8580-af39ec72e611.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e36572bf-dca7-42c7-8580-af39ec72e611.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a185",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e36572bf-dca7-42c7-8580-af39ec72e611"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e3793ba3-aeb9-43db-8c62-ef7cf8aebe3f.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e3793ba3-aeb9-43db-8c62-ef7cf8aebe3f.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a499",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e3793ba3-aeb9-43db-8c62-ef7cf8aebe3f"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e3a04129-f01c-4348-a142-50c54744b488.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e3a04129-f01c-4348-a142-50c54744b488.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a245",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e3a04129-f01c-4348-a142-50c54744b488"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e4049648-efe1-40eb-a3f1-94ae1e5e0d05.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e4049648-efe1-40eb-a3f1-94ae1e5e0d05.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a158",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e4049648-efe1-40eb-a3f1-94ae1e5e0d05"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e5a32d5f-e623-49c9-a76a-282fa1156be9.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e5a32d5f-e623-49c9-a76a-282fa1156be9.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a355",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e5a32d5f-e623-49c9-a76a-282fa1156be9"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e672d83e-9fed-467d-8ba7-749b7016a973.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e672d83e-9fed-467d-8ba7-749b7016a973.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a038",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e672d83e-9fed-467d-8ba7-749b7016a973"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e7506dd2-1b94-4238-9838-bfba71c55788.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e7506dd2-1b94-4238-9838-bfba71c55788.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a160",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e7506dd2-1b94-4238-9838-bfba71c55788"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e81e22d7-ca9c-4976-9d8b-7599300438ed.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e81e22d7-ca9c-4976-9d8b-7599300438ed.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a487",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e81e22d7-ca9c-4976-9d8b-7599300438ed"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e8c569c1-47d8-47eb-a497-956ef8377885.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/e8c569c1-47d8-47eb-a497-956ef8377885.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a485",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e8c569c1-47d8-47eb-a497-956ef8377885"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ec21b32e-c23c-4455-bef5-5a7ff987b6d2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ec21b32e-c23c-4455-bef5-5a7ff987b6d2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a193",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ec21b32e-c23c-4455-bef5-5a7ff987b6d2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/eca2aa03-eb8b-4325-b01a-03152b065b49.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/eca2aa03-eb8b-4325-b01a-03152b065b49.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a074",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "eca2aa03-eb8b-4325-b01a-03152b065b49"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ed7a4d36-e62b-4b1a-a889-914a2264d90b.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ed7a4d36-e62b-4b1a-a889-914a2264d90b.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a146",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ed7a4d36-e62b-4b1a-a889-914a2264d90b"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ee1f818f-1c2c-454b-89c8-7c9236113261.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ee1f818f-1c2c-454b-89c8-7c9236113261.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a241",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ee1f818f-1c2c-454b-89c8-7c9236113261"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ee49a3c0-769b-49e2-bfa1-173e9517379c.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ee49a3c0-769b-49e2-bfa1-173e9517379c.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a141",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ee49a3c0-769b-49e2-bfa1-173e9517379c"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ee4c90b0-22ca-49f3-bf4f-472b752fa912.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ee4c90b0-22ca-49f3-bf4f-472b752fa912.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a337",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ee4c90b0-22ca-49f3-bf4f-472b752fa912"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/effa7e3c-aebe-492e-95ab-a233e4825921.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/effa7e3c-aebe-492e-95ab-a233e4825921.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a252",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "effa7e3c-aebe-492e-95ab-a233e4825921"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f0b86972-81f8-4120-be97-3ca65e549fd2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f0b86972-81f8-4120-be97-3ca65e549fd2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a119",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f0b86972-81f8-4120-be97-3ca65e549fd2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f15b832c-229a-4f45-abb2-e141f43e830d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f15b832c-229a-4f45-abb2-e141f43e830d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a238",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f15b832c-229a-4f45-abb2-e141f43e830d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f2a66797-e9ce-4b55-8d22-dca72d2a35c5.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f2a66797-e9ce-4b55-8d22-dca72d2a35c5.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a010",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f2a66797-e9ce-4b55-8d22-dca72d2a35c5"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f2d0c794-959e-4d16-9193-20e203ef0805.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f2d0c794-959e-4d16-9193-20e203ef0805.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a497",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f2d0c794-959e-4d16-9193-20e203ef0805"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f2ea1aa9-d95d-4ce5-b274-1fc838cca1fb.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f2ea1aa9-d95d-4ce5-b274-1fc838cca1fb.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a068",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f2ea1aa9-d95d-4ce5-b274-1fc838cca1fb"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f367076a-db39-4ee2-9328-6c69298f158a.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f367076a-db39-4ee2-9328-6c69298f158a.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a112",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f367076a-db39-4ee2-9328-6c69298f158a"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f3a0cf88-5bfe-49f8-9744-25d3ad633e28.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f3a0cf88-5bfe-49f8-9744-25d3ad633e28.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a043",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f3a0cf88-5bfe-49f8-9744-25d3ad633e28"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f3bc943e-ff76-4aef-8a33-0a3605015a4d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f3bc943e-ff76-4aef-8a33-0a3605015a4d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v1.50 (07/20/2015)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a482",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f3bc943e-ff76-4aef-8a33-0a3605015a4d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f42273a7-01a9-4c3a-adf6-63aa7a0f9cc6.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f42273a7-01a9-4c3a-adf6-63aa7a0f9cc6.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a324",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f42273a7-01a9-4c3a-adf6-63aa7a0f9cc6"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f4952199-aa62-4f89-83ef-b1f4b30fe3db.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f4952199-aa62-4f89-83ef-b1f4b30fe3db.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a453",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f4952199-aa62-4f89-83ef-b1f4b30fe3db"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f52a61e0-8b6c-4cbe-8a54-5b1016c676b1.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f52a61e0-8b6c-4cbe-8a54-5b1016c676b1.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a154",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f52a61e0-8b6c-4cbe-8a54-5b1016c676b1"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f6044008-4a43-4491-b571-ba626806475d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f6044008-4a43-4491-b571-ba626806475d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a031",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f6044008-4a43-4491-b571-ba626806475d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f6937f52-0a9d-4bce-9275-fe13b6e672ed.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f6937f52-0a9d-4bce-9275-fe13b6e672ed.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a491",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f6937f52-0a9d-4bce-9275-fe13b6e672ed"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f6e4588f-853f-48e6-95ba-3f9ac8b36be4.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f6e4588f-853f-48e6-95ba-3f9ac8b36be4.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a172",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f6e4588f-853f-48e6-95ba-3f9ac8b36be4"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f6f60b48-2008-402a-9761-c73ee4de3f75.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f6f60b48-2008-402a-9761-c73ee4de3f75.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a145",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f6f60b48-2008-402a-9761-c73ee4de3f75"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f742d177-f9d5-42b4-8f54-249f12f40c50.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f742d177-f9d5-42b4-8f54-249f12f40c50.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a258",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f742d177-f9d5-42b4-8f54-249f12f40c50"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f9131d7b-5b3a-4acc-a0c0-b4c98435c122.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/f9131d7b-5b3a-4acc-a0c0-b4c98435c122.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a502",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f9131d7b-5b3a-4acc-a0c0-b4c98435c122"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fa42bc53-b2f3-4411-9b9d-17b57c6c81a0.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fa42bc53-b2f3-4411-9b9d-17b57c6c81a0.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a412",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fa42bc53-b2f3-4411-9b9d-17b57c6c81a0"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fa9e43ba-1247-4314-a877-f8c27411bdc9.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fa9e43ba-1247-4314-a877-f8c27411bdc9.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a164",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fa9e43ba-1247-4314-a877-f8c27411bdc9"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fab3ee7d-40de-4dca-904d-53545eec7370.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fab3ee7d-40de-4dca-904d-53545eec7370.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a429",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fab3ee7d-40de-4dca-904d-53545eec7370"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fad312e4-fb08-45e1-8c67-53037fd7479d.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fad312e4-fb08-45e1-8c67-53037fd7479d.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a067",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fad312e4-fb08-45e1-8c67-53037fd7479d"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fb779fc4-c6c6-4310-99e8-e5a3fc3becbf.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fb779fc4-c6c6-4310-99e8-e5a3fc3becbf.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a506",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fb779fc4-c6c6-4310-99e8-e5a3fc3becbf"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fbf3dbb0-2478-46fe-85aa-a18e107518f5.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fbf3dbb0-2478-46fe-85aa-a18e107518f5.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a366",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fbf3dbb0-2478-46fe-85aa-a18e107518f5"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fc512cc3-73a7-4c22-bfa9-60382bfdddcf.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fc512cc3-73a7-4c22-bfa9-60382bfdddcf.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a430",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fc512cc3-73a7-4c22-bfa9-60382bfdddcf"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fd001f39-d3f6-4b31-941c-4f75cd5c10ca.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fd001f39-d3f6-4b31-941c-4f75cd5c10ca.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a508",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fd001f39-d3f6-4b31-941c-4f75cd5c10ca"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fd0e8f7e-b659-4af3-a689-91726bcd5498.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fd0e8f7e-b659-4af3-a689-91726bcd5498.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a008",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fd0e8f7e-b659-4af3-a689-91726bcd5498"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fd3b1703-2599-402b-bff0-0102f0784c0e.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fd3b1703-2599-402b-bff0-0102f0784c0e.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a256",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fd3b1703-2599-402b-bff0-0102f0784c0e"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fdd6c72f-d54f-4a54-9fad-98772ad71175.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fdd6c72f-d54f-4a54-9fad-98772ad71175.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a397",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fdd6c72f-d54f-4a54-9fad-98772ad71175"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fdff382e-c249-4c84-8312-4e14ca1a39cc.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fdff382e-c249-4c84-8312-4e14ca1a39cc.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v1.50 (07/20/2015)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a021",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fdff382e-c249-4c84-8312-4e14ca1a39cc"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fe305d84-1e4e-4451-a8ba-e2df5c70ee16.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fe305d84-1e4e-4451-a8ba-e2df5c70ee16.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.76 (10/21/2019)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 256000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "snyder-a006",
+  "node_type": "indyscc_head",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fe305d84-1e4e-4451-a8ba-e2df5c70ee16"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fe312a92-3eb3-494f-b90e-df88d3bbfcd2.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/fe312a92-3eb3-494f-b90e-df88d3bbfcd2.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a053",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fe312a92-3eb3-494f-b90e-df88d3bbfcd2"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ff41370b-22fe-46c4-88fe-c9bb4ac1e9a3.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ff41370b-22fe-46c4-88fe-c9bb4ac1e9a3.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a028",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ff41370b-22fe-46c4-88fe-c9bb4ac1e9a3"
+}

--- a/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ffd3789f-dd50-4cf6-a0c1-4325e56d69ce.json
+++ b/data/chameleoncloud/sites/purdue/clusters/chameleon/nodes/ffd3789f-dd50-4cf6-a0c1-4325e56d69ce.json
@@ -1,0 +1,40 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 40
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "HPE",
+    "version": "U15 v2.30 (09/12/2016)"
+  },
+  "chassis": {
+    "manufacturer": "HPE",
+    "name": "ProLiant DL60 Gen9",
+    "serial": "777403-B21"
+  },
+  "main_memory": {
+    "humanized_ram_size": "64 GiB",
+    "ram_size": 64000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [],
+  "node_name": "rice-a106",
+  "node_type": "indyscc_compute",
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz",
+    "vendor": "Intel(R) Corporation"
+  },
+  "storage_devices": [],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ffd3789f-dd50-4cf6-a0c1-4325e56d69ce"
+}

--- a/data/chameleoncloud/sites/purdue/purdue.json
+++ b/data/chameleoncloud/sites/purdue/purdue.json
@@ -1,0 +1,12 @@
+{
+    "description": "IndySCC at Purdue",
+    "email_contact": "help@chameleoncloud.org",
+    "name": "CHI@Purdue",
+    "security_contact": "help@chameleoncloud.org",
+    "site_class": "baremetal",
+    "sys_admin_contact": "help@chameleoncloud.org",
+    "type": "site",
+    "uid": "purdue",
+    "user_support_contact": "help@chameleoncloud.org",
+    "web": "https://chi.rcac.purdue.edu"
+}


### PR DESCRIPTION
this adds the purdue IndySCC site

Due to redfish limitations on these nodes, the data does not yet include:
* network interfaces
* storage devices
* placement info