### PR TITLE
[NU] Add new hardware, update info from redfish

### DIFF
--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/0e7ec61f-6389-4148-a89e-5fd5696c5065.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/0e7ec61f-6389-4148-a89e-5fd5696c5065.json
@@ -12,7 +12,7 @@
   "chassis": {
     "manufacturer": "Dell Inc.",
     "name": "PowerEdge R630",
-    "serial": "4GRY482"
+    "serial": "334DD42"
   },
   "main_memory": {
     "humanized_ram_size": "128 GiB",
@@ -23,19 +23,10 @@
   },
   "network_adapters": [
     {
-      "device": "NIC.Slot.3-1",
-      "enabled": false,
-      "interface": "Ethernet",
-      "mac": "",
-      "management": false,
-      "model": null,
-      "vendor": null
-    },
-    {
       "device": "NIC.Integrated.1-1",
       "enabled": true,
       "interface": "Ethernet",
-      "mac": "14:18:77:54:0d:d1",
+      "mac": "44:a8:42:27:05:a5",
       "management": false,
       "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
       "rate": 10000000000,
@@ -45,7 +36,7 @@
       "device": "NIC.Integrated.1-2",
       "enabled": false,
       "interface": "Ethernet",
-      "mac": "14:18:77:54:0d:d3",
+      "mac": "44:a8:42:27:05:a7",
       "management": false,
       "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
       "vendor": "Dell"
@@ -54,7 +45,7 @@
       "device": "NIC.Integrated.1-3",
       "enabled": false,
       "interface": "Ethernet",
-      "mac": "14:18:77:54:0d:d5",
+      "mac": "44:a8:42:27:05:a9",
       "management": false,
       "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
       "vendor": "Dell"
@@ -63,14 +54,13 @@
       "device": "NIC.Integrated.1-4",
       "enabled": false,
       "interface": "Ethernet",
-      "mac": "14:18:77:54:0d:d7",
+      "mac": "44:a8:42:27:05:ab",
       "management": false,
       "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
-      "rate": 1000000000,
       "vendor": "Dell"
     }
   ],
-  "node_name": "r630cham5",
+  "node_name": "r630cham107",
   "node_type": null,
   "processor": {
     "instruction_set": "x86-64",
@@ -84,9 +74,9 @@
       "interface": "SATA",
       "media_type": "HDD",
       "model": "ST9250610NS",
-      "rev": "AA63",
+      "rev": "AA65",
       "size": 249510756352,
-      "vendor": "SEAGATE"
+      "vendor": "ATA"
     }
   ],
   "supported_job_types": {
@@ -95,5 +85,5 @@
     "virtual": "ivt"
   },
   "type": "node",
-  "uid": "b2349504-a69d-4c7d-93d3-5fd27e75d44d"
+  "uid": "0e7ec61f-6389-4148-a89e-5fd5696c5065"
 }

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/0e7ec61f-6389-4148-a89e-5fd5696c5065.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/0e7ec61f-6389-4148-a89e-5fd5696c5065.json
@@ -61,7 +61,7 @@
     }
   ],
   "node_name": "r630cham107",
-  "node_type": null,
+  "node_type": "compute_haswell",
   "processor": {
     "instruction_set": "x86-64",
     "model": "Intel(R) Xeon(R) CPU E5-2670 v3 @ 2.30GHz",

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/11b2c2db-61ef-4f67-9ddb-ca95ed167d20.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/11b2c2db-61ef-4f67-9ddb-ca95ed167d20.json
@@ -61,7 +61,7 @@
     }
   ],
   "node_name": "r630cham108",
-  "node_type": null,
+  "node_type": "compute_haswell",
   "processor": {
     "instruction_set": "x86-64",
     "model": "Intel(R) Xeon(R) CPU E5-2670 v3 @ 2.30GHz",

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/11b2c2db-61ef-4f67-9ddb-ca95ed167d20.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/11b2c2db-61ef-4f67-9ddb-ca95ed167d20.json
@@ -7,12 +7,12 @@
   "bios": {
     "release_date": null,
     "vendor": "Dell Inc.",
-    "version": "2.15.0"
+    "version": "2.13.0"
   },
   "chassis": {
     "manufacturer": "Dell Inc.",
     "name": "PowerEdge R630",
-    "serial": "4GRY482"
+    "serial": "335DD42"
   },
   "main_memory": {
     "humanized_ram_size": "128 GiB",
@@ -23,19 +23,10 @@
   },
   "network_adapters": [
     {
-      "device": "NIC.Slot.3-1",
-      "enabled": false,
-      "interface": "Ethernet",
-      "mac": "",
-      "management": false,
-      "model": null,
-      "vendor": null
-    },
-    {
       "device": "NIC.Integrated.1-1",
       "enabled": true,
       "interface": "Ethernet",
-      "mac": "14:18:77:54:0d:d1",
+      "mac": "44:a8:42:27:26:59",
       "management": false,
       "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
       "rate": 10000000000,
@@ -45,7 +36,7 @@
       "device": "NIC.Integrated.1-2",
       "enabled": false,
       "interface": "Ethernet",
-      "mac": "14:18:77:54:0d:d3",
+      "mac": "44:a8:42:27:26:5b",
       "management": false,
       "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
       "vendor": "Dell"
@@ -54,7 +45,7 @@
       "device": "NIC.Integrated.1-3",
       "enabled": false,
       "interface": "Ethernet",
-      "mac": "14:18:77:54:0d:d5",
+      "mac": "44:a8:42:27:26:5d",
       "management": false,
       "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
       "vendor": "Dell"
@@ -63,14 +54,13 @@
       "device": "NIC.Integrated.1-4",
       "enabled": false,
       "interface": "Ethernet",
-      "mac": "14:18:77:54:0d:d7",
+      "mac": "44:a8:42:27:26:5f",
       "management": false,
       "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
-      "rate": 1000000000,
       "vendor": "Dell"
     }
   ],
-  "node_name": "r630cham5",
+  "node_name": "r630cham108",
   "node_type": null,
   "processor": {
     "instruction_set": "x86-64",
@@ -95,5 +85,5 @@
     "virtual": "ivt"
   },
   "type": "node",
-  "uid": "b2349504-a69d-4c7d-93d3-5fd27e75d44d"
+  "uid": "11b2c2db-61ef-4f67-9ddb-ca95ed167d20"
 }

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/3d8645f2-2a9e-4012-aa50-3a5977c12289.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/3d8645f2-2a9e-4012-aa50-3a5977c12289.json
@@ -63,7 +63,7 @@
     }
   ],
   "node_name": "r630cham1",
-  "node_type": null,
+  "node_type": "compute_haswell",
   "processor": {
     "instruction_set": "x86-64",
     "model": "Intel(R) Xeon(R) CPU E5-2670 v3 @ 2.30GHz",

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/3d8645f2-2a9e-4012-aa50-3a5977c12289.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/3d8645f2-2a9e-4012-aa50-3a5977c12289.json
@@ -5,20 +5,17 @@
     "smt_size": 48
   },
   "bios": {
-    "release_date": "12/04/2018",
+    "release_date": null,
     "vendor": "Dell Inc.",
-    "version": "2.9.1"
+    "version": "2.15.0"
   },
   "chassis": {
     "manufacturer": "Dell Inc.",
     "name": "PowerEdge R630",
     "serial": "49Z5182"
   },
-  "gpu": {
-    "gpu": false
-  },
   "main_memory": {
-    "humanized_ram_size": "128 GB",
+    "humanized_ram_size": "128 GiB",
     "ram_size": 128000000000
   },
   "monitoring": {
@@ -26,91 +23,62 @@
   },
   "network_adapters": [
     {
-      "bridged": false,
-      "device": "eno1",
-      "driver": "bnx2x",
+      "device": "NIC.Integrated.1-1",
       "enabled": true,
       "interface": "Ethernet",
       "mac": "14:18:77:3e:8f:ef",
       "management": false,
-      "model": "Ethernet Controller X710 for 10GbE SFP+ (rev 01)",
-      "mounted": true,
+      "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
       "rate": 10000000000,
-      "vendor": "Broadcom Corporation",
-      "version": ""
+      "vendor": "Dell"
     },
     {
-      "bridged": false,
-      "device": "eno5",
-      "driver": "mlx5_core",
-      "enabled": true,
+      "device": "NIC.Integrated.1-2",
+      "enabled": false,
       "interface": "Ethernet",
-      "mac": "7c:fe:90:5c:18:c2",
+      "mac": "14:18:77:3e:8f:f1",
       "management": false,
-      "model": "MT27800 Family [ConnectX-5]",
-      "mounted": false,
-      "rate": 100000000000,
-      "vendor": "Mellanox Technologies",
-      "version": "MT4119"
+      "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
+      "vendor": "Dell"
     },
     {
-      "bridged": false,
-      "device": "eno6",
-      "driver": "mlx5_core",
-      "enabled": true,
+      "device": "NIC.Integrated.1-3",
+      "enabled": false,
       "interface": "Ethernet",
-      "mac": "7c:fe:90:12:bd:d2",
+      "mac": "14:18:77:3e:8f:f3",
       "management": false,
-      "model": "MT27800 Family [ConnectX-5]",
-      "mounted": false,
-      "rate": 100000000000,
-      "vendor": "Mellanox Technologies",
-      "version": "MT4119"
+      "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
+      "rate": 1000000000,
+      "vendor": "Dell"
     },
     {
-      "bridged": false,
-      "device": "eno7",
-      "driver": "mlx5_core",
-      "enabled": true,
+      "device": "NIC.Integrated.1-4",
+      "enabled": false,
       "interface": "Ethernet",
-      "mac": "7c:fe:90:12:bd:d3",
+      "mac": "14:18:77:3e:8f:f5",
       "management": false,
-      "model": "MT27800 Family [ConnectX-5]",
-      "mounted": false,
-      "rate": 100000000000,
-      "vendor": "Mellanox Technologies",
-      "version": "MT4119"
+      "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
+      "rate": 1000000000,
+      "vendor": "Dell"
     }
   ],
   "node_name": "r630cham1",
-  "node_type": "compute_haswell",
-  "placement": {
-    "node": 0,
-    "rack": 1
-  },
+  "node_type": null,
   "processor": {
-    "cache_l1": null,
-    "cache_l1d": 32768,
-    "cache_l1i": 32768,
-    "cache_l2": 262144,
-    "cache_l3": 31457280,
-    "clock_speed": null,
     "instruction_set": "x86-64",
-    "model": "Intel Xeon",
-    "other_description": "Intel(R) Xeon(R) CPU E5-2670 v3 @ 2.30GHz",
-    "vendor": "Intel",
-    "version": "E5-2670 v3"
+    "model": "Intel(R) Xeon(R) CPU E5-2670 v3 @ 2.30GHz",
+    "vendor": "Intel"
   },
   "storage_devices": [
     {
-      "device": "sda",
-      "driver": "megaraid_sas",
-      "humanized_size": "250 GB",
+      "device": "Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1",
+      "humanized_size": "249 GB",
       "interface": "SATA",
+      "media_type": "HDD",
       "model": "ST9250610NS",
       "rev": "AA63",
-      "size": 250059350016,
-      "vendor": "Seagate"
+      "size": 249510756352,
+      "vendor": "SEAGATE"
     }
   ],
   "supported_job_types": {

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/70292d95-644f-42d7-9744-f5308b71d5b3.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/70292d95-644f-42d7-9744-f5308b71d5b3.json
@@ -1,0 +1,142 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 48
+  },
+  "bios": {
+    "release_date": null,
+    "vendor": "Dell Inc.",
+    "version": "2.11.2"
+  },
+  "chassis": {
+    "manufacturer": "Dell Inc.",
+    "name": "PowerEdge R740xd",
+    "serial": "8MRYHL2"
+  },
+  "main_memory": {
+    "humanized_ram_size": "178 GiB",
+    "ram_size": 178000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "NIC.Slot.1-1",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "",
+      "management": false,
+      "model": null,
+      "rate": 100000000000,
+      "vendor": null
+    },
+    {
+      "device": "NIC.Slot.1-2",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "",
+      "management": false,
+      "model": null,
+      "vendor": null
+    },
+    {
+      "device": "NIC.Slot.4-1",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "",
+      "management": false,
+      "model": null,
+      "vendor": null
+    },
+    {
+      "device": "NIC.Slot.4-2",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "",
+      "management": false,
+      "model": null,
+      "rate": 100000000000,
+      "vendor": null
+    },
+    {
+      "device": "NIC.Integrated.1-3",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "24:6e:96:5b:bf:78",
+      "management": false,
+      "model": "Intel(R) 2P X710/2P I350 rNDC",
+      "rate": 1000000000,
+      "vendor": "Dell"
+    },
+    {
+      "device": "NIC.Integrated.1-4",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "24:6e:96:5b:bf:79",
+      "management": false,
+      "model": "Intel(R) 2P X710/2P I350 rNDC",
+      "vendor": "Dell"
+    },
+    {
+      "device": "NIC.Integrated.1-1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "24:6e:96:5b:bf:58",
+      "management": false,
+      "model": "Intel(R) 2P X710/2P I350 rNDC",
+      "rate": 10000000000,
+      "vendor": "Dell"
+    },
+    {
+      "device": "NIC.Integrated.1-2",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "24:6e:96:5b:bf:5a",
+      "management": false,
+      "model": "Intel(R) 2P X710/2P I350 rNDC",
+      "vendor": "Dell"
+    }
+  ],
+  "node_name": "r740xdcham143",
+  "node_type": "compute_None",
+  "placement": {
+    "node": "1",
+    "rack": ""
+  },
+  "processor": {
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) Gold 6136 CPU @ 3.00GHz",
+    "vendor": "Intel"
+  },
+  "storage_devices": [
+    {
+      "device": "Disk.Bay.0:Enclosure.Internal.0-1:RAID.Slot.7-1",
+      "humanized_size": "119 GB",
+      "interface": "SATA",
+      "media_type": "SSD",
+      "model": "SSDSC2BB120G7R",
+      "rev": "N201DL43",
+      "size": 119453777920,
+      "vendor": "ATA"
+    },
+    {
+      "device": "Disk.Bay.1:Enclosure.Internal.0-1:RAID.Slot.7-1",
+      "humanized_size": "119 GB",
+      "interface": "SATA",
+      "media_type": "SSD",
+      "model": "SSDSC2BB120G7R",
+      "rev": "N201DL43",
+      "size": 119453777920,
+      "vendor": "ATA"
+    }
+  ],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "70292d95-644f-42d7-9744-f5308b71d5b3"
+}

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/70292d95-644f-42d7-9744-f5308b71d5b3.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/70292d95-644f-42d7-9744-f5308b71d5b3.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "r740xdcham143",
-  "node_type": "compute_None",
+  "node_type": "compute_skylake",
   "placement": {
     "node": "1",
     "rack": ""

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/919b948a-d6f7-4f09-a418-28b3834c6048.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/919b948a-d6f7-4f09-a418-28b3834c6048.json
@@ -1,0 +1,147 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 48
+  },
+  "bios": {
+    "release_date": "004/21/2021",
+    "vendor": "Dell Inc.",
+    "version": "2.11.2"
+  },
+  "chassis": {
+    "manufacturer": "Dell Inc.",
+    "name": "PowerEdge R740xd",
+    "serial": "8MRXHL2"
+  },
+  "main_memory": {
+    "humanized_ram_size": "192 GiB",
+    "ram_size": 192000000000
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "NIC.Integrated.1-1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "24:6e:96:5c:ca:f6",
+      "management": false,
+      "model": "Intel(R) 2P X710/2P I350 rNDC",
+      "rate": 10000000000,
+      "vendor": "Intel Corporation"
+    },
+    {
+      "device": "NIC.Integrated.1-2",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "24:6e:96:5c:ca:f8",
+      "management": false,
+      "model": "Intel(R) 2P X710/2P I350 rNDC",
+      "vendor": "Intel Corporation"
+    },
+    {
+      "device": "NIC.Integrated.1-3",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "24:6e:96:5c:cb:16",
+      "management": false,
+      "model": "Intel(R) 2P X710/2P I350 rNDC",
+      "rate": 1000000000,
+      "vendor": "Intel Corporation"
+    },
+    {
+      "device": "NIC.Integrated.1-4",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "24:6e:96:5c:cb:17",
+      "management": false,
+      "model": "Intel(R) 2P X710/2P I350 rNDC",
+      "vendor": "Intel Corporation"
+    },
+    {
+      "device": "NIC.Slot.1-1",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "",
+      "management": false,
+      "model": null,
+      "rate": 100000000000,
+      "vendor": null
+    },
+    {
+      "device": "NIC.Slot.1-2",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "",
+      "management": false,
+      "model": null,
+      "vendor": null
+    },
+    {
+      "device": "NIC.Slot.4-1",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "",
+      "management": false,
+      "model": null,
+      "vendor": null
+    },
+    {
+      "device": "NIC.Slot.4-2",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "",
+      "management": false,
+      "model": null,
+      "rate": 100000000000,
+      "vendor": null
+    }
+  ],
+  "node_name": "r740xdcham142",
+  "node_type": "compute_None",
+  "placement": {
+    "node": "1",
+    "rack": ""
+  },
+  "processor": {
+    "cache_l1": 768000,
+    "cache_l2": 12288000,
+    "cache_l3": 25344000,
+    "clock_speed": 3000000000,
+    "instruction_set": "x86-64",
+    "model": "Intel(R) Xeon(R) Gold 6136 CPU @ 3.00GHz",
+    "vendor": "Intel",
+    "version": "Model 85 Stepping 4"
+  },
+  "storage_devices": [
+    {
+      "device": "Disk.Bay.0:Enclosure.Internal.0-1:RAID.Slot.7-1",
+      "humanized_size": "119 GB",
+      "interface": "SATA",
+      "media_type": "SSD",
+      "model": "SSDSC2BB120G7R",
+      "rev": "N201DL43",
+      "size": 119453777920,
+      "vendor": "INTEL"
+    },
+    {
+      "device": "Disk.Bay.1:Enclosure.Internal.0-1:RAID.Slot.7-1",
+      "humanized_size": "119 GB",
+      "interface": "SATA",
+      "media_type": "SSD",
+      "model": "SSDSC2BB120G7R",
+      "rev": "N201DL43",
+      "size": 119453777920,
+      "vendor": "INTEL"
+    }
+  ],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "919b948a-d6f7-4f09-a418-28b3834c6048"
+}

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/919b948a-d6f7-4f09-a418-28b3834c6048.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/919b948a-d6f7-4f09-a418-28b3834c6048.json
@@ -100,7 +100,7 @@
     }
   ],
   "node_name": "r740xdcham142",
-  "node_type": "compute_None",
+  "node_type": "compute_skylake",
   "placement": {
     "node": "1",
     "rack": ""

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/a44abddb-110b-4b9e-8606-353d2e2705a4.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/a44abddb-110b-4b9e-8606-353d2e2705a4.json
@@ -61,7 +61,7 @@
     }
   ],
   "node_name": "r630cham106",
-  "node_type": null,
+  "node_type": "compute_haswell",
   "processor": {
     "instruction_set": "x86-64",
     "model": "Intel(R) Xeon(R) CPU E5-2670 v3 @ 2.30GHz",

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/a44abddb-110b-4b9e-8606-353d2e2705a4.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/a44abddb-110b-4b9e-8606-353d2e2705a4.json
@@ -12,7 +12,7 @@
   "chassis": {
     "manufacturer": "Dell Inc.",
     "name": "PowerEdge R630",
-    "serial": "4GRY482"
+    "serial": "333FD42"
   },
   "main_memory": {
     "humanized_ram_size": "128 GiB",
@@ -23,19 +23,10 @@
   },
   "network_adapters": [
     {
-      "device": "NIC.Slot.3-1",
-      "enabled": false,
-      "interface": "Ethernet",
-      "mac": "",
-      "management": false,
-      "model": null,
-      "vendor": null
-    },
-    {
       "device": "NIC.Integrated.1-1",
       "enabled": true,
       "interface": "Ethernet",
-      "mac": "14:18:77:54:0d:d1",
+      "mac": "44:a8:42:27:27:85",
       "management": false,
       "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
       "rate": 10000000000,
@@ -45,7 +36,7 @@
       "device": "NIC.Integrated.1-2",
       "enabled": false,
       "interface": "Ethernet",
-      "mac": "14:18:77:54:0d:d3",
+      "mac": "44:a8:42:27:27:87",
       "management": false,
       "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
       "vendor": "Dell"
@@ -54,7 +45,7 @@
       "device": "NIC.Integrated.1-3",
       "enabled": false,
       "interface": "Ethernet",
-      "mac": "14:18:77:54:0d:d5",
+      "mac": "44:a8:42:27:27:89",
       "management": false,
       "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
       "vendor": "Dell"
@@ -63,14 +54,13 @@
       "device": "NIC.Integrated.1-4",
       "enabled": false,
       "interface": "Ethernet",
-      "mac": "14:18:77:54:0d:d7",
+      "mac": "44:a8:42:27:27:8b",
       "management": false,
       "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
-      "rate": 1000000000,
       "vendor": "Dell"
     }
   ],
-  "node_name": "r630cham5",
+  "node_name": "r630cham106",
   "node_type": null,
   "processor": {
     "instruction_set": "x86-64",
@@ -84,7 +74,7 @@
       "interface": "SATA",
       "media_type": "HDD",
       "model": "ST9250610NS",
-      "rev": "AA63",
+      "rev": "AA65",
       "size": 249510756352,
       "vendor": "SEAGATE"
     }
@@ -95,5 +85,5 @@
     "virtual": "ivt"
   },
   "type": "node",
-  "uid": "b2349504-a69d-4c7d-93d3-5fd27e75d44d"
+  "uid": "a44abddb-110b-4b9e-8606-353d2e2705a4"
 }

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/b2349504-a69d-4c7d-93d3-5fd27e75d44d.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/b2349504-a69d-4c7d-93d3-5fd27e75d44d.json
@@ -71,7 +71,7 @@
     }
   ],
   "node_name": "r630cham5",
-  "node_type": null,
+  "node_type": "compute_haswell",
   "processor": {
     "instruction_set": "x86-64",
     "model": "Intel(R) Xeon(R) CPU E5-2670 v3 @ 2.30GHz",

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/cb60c8ea-0bb7-4ab8-8d50-600db2f130f7.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/cb60c8ea-0bb7-4ab8-8d50-600db2f130f7.json
@@ -5,20 +5,17 @@
     "smt_size": 48
   },
   "bios": {
-    "release_date": "005/17/2018",
+    "release_date": null,
     "vendor": "Dell Inc.",
-    "version": "2.8.0"
+    "version": "2.15.0"
   },
   "chassis": {
     "manufacturer": "Dell Inc.",
     "name": "PowerEdge R630",
     "serial": "49Z6182"
   },
-  "gpu": {
-    "gpu": false
-  },
   "main_memory": {
-    "humanized_ram_size": "128 GB",
+    "humanized_ram_size": "128 GiB",
     "ram_size": 128000000000
   },
   "monitoring": {
@@ -26,63 +23,70 @@
   },
   "network_adapters": [
     {
-      "bridged": false,
-      "device": "eno1",
-      "driver": "bnx2x",
+      "device": "NIC.Slot.3-1",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "",
+      "management": false,
+      "model": null,
+      "rate": 100000000000,
+      "vendor": null
+    },
+    {
+      "device": "NIC.Integrated.1-1",
       "enabled": true,
       "interface": "Ethernet",
       "mac": "b0:83:fe:eb:5a:e7",
       "management": false,
-      "model": "Ethernet Controller X710 for 10GbE SFP+ (rev 01)",
-      "mounted": true,
+      "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
       "rate": 10000000000,
-      "vendor": "Broadcom Corporation",
-      "version": ""
+      "vendor": "Dell"
     },
     {
-      "bridged": false,
-      "device": "eno3",
-      "driver": "mlx5_core",
-      "enabled": true,
+      "device": "NIC.Integrated.1-2",
+      "enabled": false,
       "interface": "Ethernet",
-      "mac": "98:03:9b:7f:bb:08",
+      "mac": "b0:83:fe:eb:5a:e9",
       "management": false,
-      "model": "MT27800 Family [ConnectX-5]",
-      "mounted": false,
-      "rate": 100000000000,
-      "vendor": "Mellanox Technologies",
-      "version": "MT4119"
+      "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
+      "vendor": "Dell"
+    },
+    {
+      "device": "NIC.Integrated.1-3",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "b0:83:fe:eb:5a:eb",
+      "management": false,
+      "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
+      "vendor": "Dell"
+    },
+    {
+      "device": "NIC.Integrated.1-4",
+      "enabled": false,
+      "interface": "Ethernet",
+      "mac": "b0:83:fe:eb:5a:ed",
+      "management": false,
+      "model": "BRCM 10G/GbE 2+2P 57800 rNDC",
+      "vendor": "Dell"
     }
   ],
   "node_name": "r630cham3",
-  "node_type": "compute_haswell",
-  "placement": {
-    "node": 0,
-    "rack": 1
-  },
+  "node_type": null,
   "processor": {
-    "cache_l1": null,
-    "cache_l1d": 32768,
-    "cache_l1i": 32768,
-    "cache_l2": 262144,
-    "cache_l3": 31457280,
-    "clock_speed": null,
     "instruction_set": "x86-64",
-    "model": "Intel Xeon",
-    "other_description": "Intel(R) Xeon(R) CPU E5-2670 v3 @ 2.30GHz",
-    "vendor": "Intel",
-    "version": "E5-2670 v3"
+    "model": "Intel(R) Xeon(R) CPU E5-2670 v3 @ 2.30GHz",
+    "vendor": "Intel"
   },
   "storage_devices": [
     {
-      "device": "sda",
-      "driver": "megaraid_sas",
-      "humanized_size": "1 TB",
+      "device": "Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1",
+      "humanized_size": "999 GB",
       "interface": "SATA",
+      "media_type": "HDD",
       "model": "ST1000NX0443",
       "rev": "NB33",
-      "size": 1000204886016,
-      "vendor": "Seagate"
+      "size": 999653638144,
+      "vendor": "SEAGATE"
     }
   ],
   "supported_job_types": {

--- a/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/cb60c8ea-0bb7-4ab8-8d50-600db2f130f7.json
+++ b/data/chameleoncloud/sites/nu/clusters/chameleon/nodes/cb60c8ea-0bb7-4ab8-8d50-600db2f130f7.json
@@ -71,7 +71,7 @@
     }
   ],
   "node_name": "r630cham3",
-  "node_type": null,
+  "node_type": "compute_haswell",
   "processor": {
     "instruction_set": "x86-64",
     "model": "Intel(R) Xeon(R) CPU E5-2670 v3 @ 2.30GHz",


### PR DESCRIPTION
First pass, `node_type` is not set, or not set correctly for all nodes. This is because the redfish inspector is using a very simple heuristic to guess, and this should be set manually for the moment.