### PR TITLE
Add IIT Associate Site

### DIFF
--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/001767be-c2a5-47fe-837c-66328a477346.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/001767be-c2a5-47fe-837c-66328a477346.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:f9:ea"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:f9:ec"
+    }
+  ],
+  "node_name": "c29",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "001767be-c2a5-47fe-837c-66328a477346"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/03f88710-ca32-4aa5-9f5f-0cca61d12e08.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/03f88710-ca32-4aa5-9f5f-0cca61d12e08.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:d1:48"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:d1:4a"
+    }
+  ],
+  "node_name": "c03",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "03f88710-ca32-4aa5-9f5f-0cca61d12e08"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/04e68766-004a-4507-a38e-1bbd4e08db26.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/04e68766-004a-4507-a38e-1bbd4e08db26.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b1:d7"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b1:d9"
+    }
+  ],
+  "node_name": "c76",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "04e68766-004a-4507-a38e-1bbd4e08db26"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/05beab02-2fc2-4b33-9c3c-aacaf474536e.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/05beab02-2fc2-4b33-9c3c-aacaf474536e.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:4a:50"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:4a:52"
+    }
+  ],
+  "node_name": "c23",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "05beab02-2fc2-4b33-9c3c-aacaf474536e"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/07c71e82-7252-466b-a2f2-8b5bf34c9f1f.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/07c71e82-7252-466b-a2f2-8b5bf34c9f1f.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:7b:6c"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:7b:6e"
+    }
+  ],
+  "node_name": "c32",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "07c71e82-7252-466b-a2f2-8b5bf34c9f1f"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/13f73d25-e5b4-4966-a043-814b805eb2c8.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/13f73d25-e5b4-4966-a043-814b805eb2c8.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:79:0a"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:79:0c"
+    }
+  ],
+  "node_name": "c64",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "13f73d25-e5b4-4966-a043-814b805eb2c8"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/1a034366-8f1b-468f-861f-52cdf7907816.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/1a034366-8f1b-468f-861f-52cdf7907816.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:4f:a8"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:4f:aa"
+    }
+  ],
+  "node_name": "c20",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1a034366-8f1b-468f-861f-52cdf7907816"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/1af55564-afed-4b3a-9050-3a77e69216cf.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/1af55564-afed-4b3a-9050-3a77e69216cf.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:6f:76"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:6f:78"
+    }
+  ],
+  "node_name": "c60",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1af55564-afed-4b3a-9050-3a77e69216cf"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/1b2fff5b-8338-460d-87af-4b9e3f788d69.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/1b2fff5b-8338-460d-87af-4b9e3f788d69.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b3:6f"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b3:71"
+    }
+  ],
+  "node_name": "c04",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1b2fff5b-8338-460d-87af-4b9e3f788d69"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/1eaec9b1-0f6c-4723-a830-5d781573cae1.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/1eaec9b1-0f6c-4723-a830-5d781573cae1.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:50:39"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:50:3b"
+    }
+  ],
+  "node_name": "c75",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "1eaec9b1-0f6c-4723-a830-5d781573cae1"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/20713d3f-e3cf-48ae-a131-9f57d3707944.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/20713d3f-e3cf-48ae-a131-9f57d3707944.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:6c:7c"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:6c:7e"
+    }
+  ],
+  "node_name": "c78",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "20713d3f-e3cf-48ae-a131-9f57d3707944"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/221e3243-de42-44e0-a882-c7763b490c58.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/221e3243-de42-44e0-a882-c7763b490c58.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "14:18:77:31:e4:73"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "14:18:77:31:e4:75"
+    }
+  ],
+  "node_name": "c37",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "221e3243-de42-44e0-a882-c7763b490c58"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/239b8e36-446c-4917-af64-363cb09b694c.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/239b8e36-446c-4917-af64-363cb09b694c.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b2:b9"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b2:bb"
+    }
+  ],
+  "node_name": "c70",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "239b8e36-446c-4917-af64-363cb09b694c"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/264a5563-f522-41a5-8676-28beeb97c4fa.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/264a5563-f522-41a5-8676-28beeb97c4fa.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:68:1f"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:68:21"
+    }
+  ],
+  "node_name": "c12",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "264a5563-f522-41a5-8676-28beeb97c4fa"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/29712723-8bce-4b9e-a9ab-539fb04592b5.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/29712723-8bce-4b9e-a9ab-539fb04592b5.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c8:ce"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c8:d0"
+    }
+  ],
+  "node_name": "c80",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "29712723-8bce-4b9e-a9ab-539fb04592b5"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/2afcd761-35bd-4c2a-a105-095a906dd89e.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/2afcd761-35bd-4c2a-a105-095a906dd89e.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:52:f0"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:52:f2"
+    }
+  ],
+  "node_name": "c67",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "2afcd761-35bd-4c2a-a105-095a906dd89e"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/321d59ad-ef6a-4d94-a85a-95af7b3760b4.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/321d59ad-ef6a-4d94-a85a-95af7b3760b4.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:3f:43"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:3f:45"
+    }
+  ],
+  "node_name": "c65",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "321d59ad-ef6a-4d94-a85a-95af7b3760b4"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/35ffd85d-eb97-435f-ae3d-607856c674d2.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/35ffd85d-eb97-435f-ae3d-607856c674d2.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b4:bd"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b4:bf"
+    }
+  ],
+  "node_name": "c63",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "35ffd85d-eb97-435f-ae3d-607856c674d2"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/371ce643-eda5-470e-96d3-d3dde67e2f85.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/371ce643-eda5-470e-96d3-d3dde67e2f85.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:f4:28"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:f4:2a"
+    }
+  ],
+  "node_name": "c51",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "371ce643-eda5-470e-96d3-d3dde67e2f85"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/3f94ea1f-edc1-446f-8613-95d92f17bb70.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/3f94ea1f-edc1-446f-8613-95d92f17bb70.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:b2:11"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:b2:13"
+    }
+  ],
+  "node_name": "c22",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "3f94ea1f-edc1-446f-8613-95d92f17bb70"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/41d448e2-4ff5-483e-986a-515c7292a498.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/41d448e2-4ff5-483e-986a-515c7292a498.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:ca:44"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:ca:46"
+    }
+  ],
+  "node_name": "c39",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "41d448e2-4ff5-483e-986a-515c7292a498"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/426f2ea5-fd05-4f5c-b91b-85971e32685a.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/426f2ea5-fd05-4f5c-b91b-85971e32685a.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:58:a5"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:58:a7"
+    }
+  ],
+  "node_name": "c13",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "426f2ea5-fd05-4f5c-b91b-85971e32685a"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/480632d5-9d09-4d4b-b332-a274ff3643db.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/480632d5-9d09-4d4b-b332-a274ff3643db.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:59:4d"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:59:4f"
+    }
+  ],
+  "node_name": "c56",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "480632d5-9d09-4d4b-b332-a274ff3643db"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/4d710088-a7b5-4f80-9433-c67115d9e70c.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/4d710088-a7b5-4f80-9433-c67115d9e70c.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b4:df"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b4:e1"
+    }
+  ],
+  "node_name": "c35",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "4d710088-a7b5-4f80-9433-c67115d9e70c"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/5415f6db-f269-4d33-8deb-2e56d28c2c78.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/5415f6db-f269-4d33-8deb-2e56d28c2c78.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:75:3c"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:75:3e"
+    }
+  ],
+  "node_name": "c55",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5415f6db-f269-4d33-8deb-2e56d28c2c78"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/5536431e-efcc-40b8-9e8c-9ff400a45920.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/5536431e-efcc-40b8-9e8c-9ff400a45920.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:74:42"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:74:44"
+    }
+  ],
+  "node_name": "c42",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5536431e-efcc-40b8-9e8c-9ff400a45920"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/5793bf72-b0b1-4867-bd9a-764954bedb6a.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/5793bf72-b0b1-4867-bd9a-764954bedb6a.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b9:b8"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b9:ba"
+    }
+  ],
+  "node_name": "c15",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5793bf72-b0b1-4867-bd9a-764954bedb6a"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/5d6d4ae5-2dce-4950-9d91-a7f0bdb34a9e.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/5d6d4ae5-2dce-4950-9d91-a7f0bdb34a9e.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:c9:2e"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:c9:30"
+    }
+  ],
+  "node_name": "c50",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "5d6d4ae5-2dce-4950-9d91-a7f0bdb34a9e"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/626bda83-0044-4278-a999-e4f5af75e188.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/626bda83-0044-4278-a999-e4f5af75e188.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:be:12"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:be:14"
+    }
+  ],
+  "node_name": "c54",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "626bda83-0044-4278-a999-e4f5af75e188"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/679a7847-07a8-4616-b766-a48f14745c9a.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/679a7847-07a8-4616-b766-a48f14745c9a.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:74:ba"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:74:bc"
+    }
+  ],
+  "node_name": "c09",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "679a7847-07a8-4616-b766-a48f14745c9a"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/6acc921d-5b51-4708-932e-5184cc25ce90.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/6acc921d-5b51-4708-932e-5184cc25ce90.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:9a:e9"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:9a:eb"
+    }
+  ],
+  "node_name": "c30",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "6acc921d-5b51-4708-932e-5184cc25ce90"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/735cad6f-bd6d-4a25-b5cb-9c1e14f81392.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/735cad6f-bd6d-4a25-b5cb-9c1e14f81392.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:69:87"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:69:89"
+    }
+  ],
+  "node_name": "c17",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "735cad6f-bd6d-4a25-b5cb-9c1e14f81392"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/740aca44-1374-4da7-acda-5dde90448367.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/740aca44-1374-4da7-acda-5dde90448367.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:f4:04"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:f4:06"
+    }
+  ],
+  "node_name": "c52",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "740aca44-1374-4da7-acda-5dde90448367"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/76545e44-8b44-43d8-8a83-d5daa85a2cc5.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/76545e44-8b44-43d8-8a83-d5daa85a2cc5.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:9b:79"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:9b:7b"
+    }
+  ],
+  "node_name": "c24",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "76545e44-8b44-43d8-8a83-d5daa85a2cc5"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/78b19297-c072-4a44-ad0c-04f1b1db7f3f.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/78b19297-c072-4a44-ad0c-04f1b1db7f3f.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:67:9b"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:67:9d"
+    }
+  ],
+  "node_name": "c01",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "78b19297-c072-4a44-ad0c-04f1b1db7f3f"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/7a08e0a0-76b9-466d-baac-3105a1c0b6e3.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/7a08e0a0-76b9-466d-baac-3105a1c0b6e3.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:ad:b5"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:ad:b7"
+    }
+  ],
+  "node_name": "c58",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7a08e0a0-76b9-466d-baac-3105a1c0b6e3"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/7cffe3eb-d927-4fab-9f2a-040876f4f11e.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/7cffe3eb-d927-4fab-9f2a-040876f4f11e.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:af:71"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:af:73"
+    }
+  ],
+  "node_name": "c07",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7cffe3eb-d927-4fab-9f2a-040876f4f11e"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/7faeaeae-f443-4f61-b9d8-213a7a1438b1.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/7faeaeae-f443-4f61-b9d8-213a7a1438b1.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:75:18"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:75:1a"
+    }
+  ],
+  "node_name": "c05",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "7faeaeae-f443-4f61-b9d8-213a7a1438b1"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/86d47c19-7a23-4285-99af-317beca717d6.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/86d47c19-7a23-4285-99af-317beca717d6.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:46:c2"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:46:c4"
+    }
+  ],
+  "node_name": "c38",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "86d47c19-7a23-4285-99af-317beca717d6"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/890a80d0-ac11-45c1-9ddc-7f32e293680b.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/890a80d0-ac11-45c1-9ddc-7f32e293680b.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:7a:c6"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:7a:c8"
+    }
+  ],
+  "node_name": "c68",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "890a80d0-ac11-45c1-9ddc-7f32e293680b"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/893d4982-5084-473d-ac9d-ad637ca70df0.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/893d4982-5084-473d-ac9d-ad637ca70df0.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b3:93"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b3:95"
+    }
+  ],
+  "node_name": "c66",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "893d4982-5084-473d-ac9d-ad637ca70df0"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/8ac56623-88be-41f4-b7c8-0d12e6ac2007.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/8ac56623-88be-41f4-b7c8-0d12e6ac2007.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:6f:24"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:6f:26"
+    }
+  ],
+  "node_name": "c18",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8ac56623-88be-41f4-b7c8-0d12e6ac2007"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/8bb85bfe-d30d-4780-a2b9-a15af6e2fb1f.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/8bb85bfe-d30d-4780-a2b9-a15af6e2fb1f.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:41:af"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:41:b1"
+    }
+  ],
+  "node_name": "c83",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "8bb85bfe-d30d-4780-a2b9-a15af6e2fb1f"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/940ecafe-fa31-4c38-a5f0-cadf945491b3.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/940ecafe-fa31-4c38-a5f0-cadf945491b3.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "14:18:77:32:16:4d"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "14:18:77:32:16:4f"
+    }
+  ],
+  "node_name": "c45",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "940ecafe-fa31-4c38-a5f0-cadf945491b3"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/9b67feac-0e04-40b1-a872-0618fdafe2f4.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/9b67feac-0e04-40b1-a872-0618fdafe2f4.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:86:c5"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:86:c7"
+    }
+  ],
+  "node_name": "c77",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "9b67feac-0e04-40b1-a872-0618fdafe2f4"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/a2037824-2147-4c49-834e-2f8e0117bd60.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/a2037824-2147-4c49-834e-2f8e0117bd60.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:bf:00"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:bf:02"
+    }
+  ],
+  "node_name": "c34",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a2037824-2147-4c49-834e-2f8e0117bd60"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/a2a9af70-ec0a-4c4f-94eb-40ef8e8408f5.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/a2a9af70-ec0a-4c4f-94eb-40ef8e8408f5.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c4:dd"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c4:df"
+    }
+  ],
+  "node_name": "c14",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a2a9af70-ec0a-4c4f-94eb-40ef8e8408f5"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/a339173f-c180-4241-84ba-c3dc3ff9d583.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/a339173f-c180-4241-84ba-c3dc3ff9d583.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:95:a2"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:95:a4"
+    }
+  ],
+  "node_name": "c71",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a339173f-c180-4241-84ba-c3dc3ff9d583"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/a3c15985-072b-4ce9-83fc-d608cdd1bebe.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/a3c15985-072b-4ce9-83fc-d608cdd1bebe.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:69:f2"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:69:f4"
+    }
+  ],
+  "node_name": "c25",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a3c15985-072b-4ce9-83fc-d608cdd1bebe"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/a67639c3-a7af-4feb-8507-48e48db08ce1.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/a67639c3-a7af-4feb-8507-48e48db08ce1.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:a1:99"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:a1:9b"
+    }
+  ],
+  "node_name": "c73",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a67639c3-a7af-4feb-8507-48e48db08ce1"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/a6f2a617-fda8-47d4-a973-409dbf691557.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/a6f2a617-fda8-47d4-a973-409dbf691557.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b5:87"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b5:89"
+    }
+  ],
+  "node_name": "c59",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "a6f2a617-fda8-47d4-a973-409dbf691557"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/ad9b9a19-11f9-4405-a3a5-f449ad0f3d23.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/ad9b9a19-11f9-4405-a3a5-f449ad0f3d23.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:65:aa"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:65:ac"
+    }
+  ],
+  "node_name": "c21",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ad9b9a19-11f9-4405-a3a5-f449ad0f3d23"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/b3d783a9-9fc3-4670-9d8e-5a6061808251.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/b3d783a9-9fc3-4670-9d8e-5a6061808251.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:69:da"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:69:dc"
+    }
+  ],
+  "node_name": "c47",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b3d783a9-9fc3-4670-9d8e-5a6061808251"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/b7f64e8e-e96d-4832-8b5d-6d331b48de3d.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/b7f64e8e-e96d-4832-8b5d-6d331b48de3d.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:6c:0e"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:6c:10"
+    }
+  ],
+  "node_name": "c02",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b7f64e8e-e96d-4832-8b5d-6d331b48de3d"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/c09a26f5-8775-438a-b970-87dc67fb8212.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/c09a26f5-8775-438a-b970-87dc67fb8212.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:d0:b8"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:d0:ba"
+    }
+  ],
+  "node_name": "c61",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c09a26f5-8775-438a-b970-87dc67fb8212"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/c56bc350-8fab-4fb7-a703-b20e7a19e9a5.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/c56bc350-8fab-4fb7-a703-b20e7a19e9a5.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:70:f0"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:70:f2"
+    }
+  ],
+  "node_name": "c08",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c56bc350-8fab-4fb7-a703-b20e7a19e9a5"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/c8fcf219-58d5-4661-864b-4efd3c661bbc.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/c8fcf219-58d5-4661-864b-4efd3c661bbc.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b1:ef"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b1:f1"
+    }
+  ],
+  "node_name": "c11",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "c8fcf219-58d5-4661-864b-4efd3c661bbc"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/cbcc23d0-5188-4938-91e9-790f148ad77a.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/cbcc23d0-5188-4938-91e9-790f148ad77a.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:9e:4d"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:9e:4f"
+    }
+  ],
+  "node_name": "c48",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "cbcc23d0-5188-4938-91e9-790f148ad77a"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/cc62a011-ce1f-4bfd-b94c-9bfef4183ec3.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/cc62a011-ce1f-4bfd-b94c-9bfef4183ec3.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c1:08"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c1:0a"
+    }
+  ],
+  "node_name": "c33",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "cc62a011-ce1f-4bfd-b94c-9bfef4183ec3"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/d5d5943f-a3e9-44bd-a740-c37c2e16a535.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/d5d5943f-a3e9-44bd-a740-c37c2e16a535.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:a6:a3"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:a6:a5"
+    }
+  ],
+  "node_name": "c44",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d5d5943f-a3e9-44bd-a740-c37c2e16a535"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/d7f407bd-7cc4-4ae7-9e65-6ccefde4dfab.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/d7f407bd-7cc4-4ae7-9e65-6ccefde4dfab.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "b8:2a:72:dc:d4:08"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "b8:2a:72:dc:d4:0a"
+    }
+  ],
+  "node_name": "c46",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d7f407bd-7cc4-4ae7-9e65-6ccefde4dfab"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/d82d490d-36b7-4824-b0c8-a88bfa9c682d.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/d82d490d-36b7-4824-b0c8-a88bfa9c682d.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c5:79"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c5:7b"
+    }
+  ],
+  "node_name": "c36",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d82d490d-36b7-4824-b0c8-a88bfa9c682d"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/da0546dc-286f-48ac-83fc-9ffcdbc297a4.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/da0546dc-286f-48ac-83fc-9ffcdbc297a4.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:ab:51"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:ab:53"
+    }
+  ],
+  "node_name": "c82",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "da0546dc-286f-48ac-83fc-9ffcdbc297a4"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/de14dee0-4eb4-45cb-96e5-4a213e767596.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/de14dee0-4eb4-45cb-96e5-4a213e767596.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c6:f1"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c6:f3"
+    }
+  ],
+  "node_name": "c19",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "de14dee0-4eb4-45cb-96e5-4a213e767596"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/decec495-6fe6-44cd-95cd-b0e1a5cb9bef.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/decec495-6fe6-44cd-95cd-b0e1a5cb9bef.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:64:29"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:64:2b"
+    }
+  ],
+  "node_name": "c06",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "decec495-6fe6-44cd-95cd-b0e1a5cb9bef"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/e352f2bc-988d-4b96-9b01-51aab223c958.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/e352f2bc-988d-4b96-9b01-51aab223c958.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c0:c8"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c0:ca"
+    }
+  ],
+  "node_name": "c31",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e352f2bc-988d-4b96-9b01-51aab223c958"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/e37716fe-a180-4f99-b818-3dca2cb54ecc.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/e37716fe-a180-4f99-b818-3dca2cb54ecc.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c2:70"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c2:72"
+    }
+  ],
+  "node_name": "c16",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e37716fe-a180-4f99-b818-3dca2cb54ecc"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/e413f8a0-0cca-4a78-84e5-882eb6563081.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/e413f8a0-0cca-4a78-84e5-882eb6563081.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:6b:d4"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:6b:d6"
+    }
+  ],
+  "node_name": "c79",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e413f8a0-0cca-4a78-84e5-882eb6563081"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/e5b8b847-1beb-40ed-b820-75dc0ed60f83.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/e5b8b847-1beb-40ed-b820-75dc0ed60f83.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:a0:ef"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:a0:f1"
+    }
+  ],
+  "node_name": "c27",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "e5b8b847-1beb-40ed-b820-75dc0ed60f83"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/ea39c92d-828b-486c-8197-bc9ef2fa3f28.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/ea39c92d-828b-486c-8197-bc9ef2fa3f28.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:3f:4f"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:3f:51"
+    }
+  ],
+  "node_name": "c41",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ea39c92d-828b-486c-8197-bc9ef2fa3f28"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/ed18f199-5bf1-45b5-b628-125b78735adc.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/ed18f199-5bf1-45b5-b628-125b78735adc.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:63:52"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:63:54"
+    }
+  ],
+  "node_name": "c28",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "ed18f199-5bf1-45b5-b628-125b78735adc"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/f196d631-6568-441f-a9f0-29f06b2c3da9.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/f196d631-6568-441f-a9f0-29f06b2c3da9.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:76:c4"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:76:c6"
+    }
+  ],
+  "node_name": "c62",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f196d631-6568-441f-a9f0-29f06b2c3da9"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/f43f27fe-2c2d-48cf-9860-239b1774161a.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/f43f27fe-2c2d-48cf-9860-239b1774161a.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:be:66"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:be:68"
+    }
+  ],
+  "node_name": "c74",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f43f27fe-2c2d-48cf-9860-239b1774161a"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/f4d3d478-84ff-4151-bd8d-c2045201c21b.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/f4d3d478-84ff-4151-bd8d-c2045201c21b.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:7b:84"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:7b:86"
+    }
+  ],
+  "node_name": "c10",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f4d3d478-84ff-4151-bd8d-c2045201c21b"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/f8c2910b-9f40-4cad-8a6a-5ee6ed229a53.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/f8c2910b-9f40-4cad-8a6a-5ee6ed229a53.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:f6:f8"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:f6:fa"
+    }
+  ],
+  "node_name": "c49",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f8c2910b-9f40-4cad-8a6a-5ee6ed229a53"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/f90aa55c-c786-4f3f-8293-5b6de8663d06.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/f90aa55c-c786-4f3f-8293-5b6de8663d06.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:43:66"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:43:68"
+    }
+  ],
+  "node_name": "c84",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f90aa55c-c786-4f3f-8293-5b6de8663d06"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/f9a15b01-96ba-4a7f-bcaa-6605e530d911.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/f9a15b01-96ba-4a7f-bcaa-6605e530d911.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b5:29"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:b5:2b"
+    }
+  ],
+  "node_name": "c72",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "f9a15b01-96ba-4a7f-bcaa-6605e530d911"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/fb2d0cdd-b1cf-4873-abd0-0dba5b1c1b24.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/fb2d0cdd-b1cf-4873-abd0-0dba5b1c1b24.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c1:d6"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:c1:d8"
+    }
+  ],
+  "node_name": "c40",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fb2d0cdd-b1cf-4873-abd0-0dba5b1c1b24"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/fc791f64-c337-414d-9316-624309fecb13.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/fc791f64-c337-414d-9316-624309fecb13.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:fe:16"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:16:fe:18"
+    }
+  ],
+  "node_name": "c26",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fc791f64-c337-414d-9316-624309fecb13"
+}

--- a/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/fcf877e8-b44d-4aaf-b165-ebe7a43caa5c.json
+++ b/data/chameleoncloud/sites/iit/clusters/chameleon/nodes/fcf877e8-b44d-4aaf-b165-ebe7a43caa5c.json
@@ -1,0 +1,28 @@
+{
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eth0",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:71:50"
+    },
+    {
+      "device": "eth1",
+      "enabled": true,
+      "interface": "Ethernet",
+      "mac": "44:a8:42:15:71:52"
+    }
+  ],
+  "node_name": "c57",
+  "node_type": "compute_haswell",
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "fcf877e8-b44d-4aaf-b165-ebe7a43caa5c"
+}

--- a/data/chameleoncloud/sites/iit/iit.json
+++ b/data/chameleoncloud/sites/iit/iit.json
@@ -1,0 +1,15 @@
+{
+    "uid": "iit",
+    "name": "CHI@IIT",
+    "type": "site",
+    "site_class": "baremetal",
+    "description": "Illinois Institute of Technology",
+    "web": "https://chameleon.cs.iit.edu",
+    "email_contact": "help@chameleoncloud.org",
+    "security_contact": "help@chameleoncloud.org",
+    "sys_admin_contact": "help@chameleoncloud.org",
+    "user_support_contact": "help@chameleoncloud.org",
+    "location": "10 W 31st St, Chicago, IL 60616, USA",
+    "latitude": 41.838774163502755,
+    "longitude": -87.62734428783205
+}


### PR DESCRIPTION
Add site config and nodes for IIT site.

Note: data is statically generated from hardware enrollment info, not yet live inventory data.