### PR TITLE
[UC] add compute_cascadelake_r_ib node_type

### DIFF
--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/30fd8160-939f-4ba6-8c85-deb4df593d61.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/30fd8160-939f-4ba6-8c85-deb4df593d61.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-034",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "34",
     "rack": "BG-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/3e79e685-1a53-48ed-a67f-6afb03572839.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/3e79e685-1a53-48ed-a67f-6afb03572839.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-035",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "36",
     "rack": "BG-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/5bc4b84d-e791-42bf-862e-f46a25fd7b63.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/5bc4b84d-e791-42bf-862e-f46a25fd7b63.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-019",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "42",
     "rack": "BI-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/65c744bb-81ea-4fa8-a5f7-998dc315b4f9.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/65c744bb-81ea-4fa8-a5f7-998dc315b4f9.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-014",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "32",
     "rack": "BI-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/89e48f7e-d04f-4455-b093-2a4318fb7026.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/89e48f7e-d04f-4455-b093-2a4318fb7026.json
@@ -78,7 +78,7 @@
     }
   ],
   "node_name": "P3-CPU-038",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "42",
     "rack": "BG-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/926a9c99-3b27-45a7-818c-e6525b9ce89c.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/926a9c99-3b27-45a7-818c-e6525b9ce89c.json
@@ -78,7 +78,7 @@
     }
   ],
   "node_name": "P3-CPU-042",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "43",
     "rack": "BH-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/9ae9a4bd-5157-4f6b-930d-ea5739ff86f6.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/9ae9a4bd-5157-4f6b-930d-ea5739ff86f6.json
@@ -70,7 +70,7 @@
     }
   ],
   "node_name": "P3-CPU-041",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "41",
     "rack": "BH-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/9e0debfa-9e6a-4c78-809f-7eb7666166dc.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/9e0debfa-9e6a-4c78-809f-7eb7666166dc.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-016",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "36",
     "rack": "BI-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/a84f10dd-e99b-424c-b923-ee3c21a642cc.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/a84f10dd-e99b-424c-b923-ee3c21a642cc.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-040",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "39",
     "rack": "BH-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/ab40170d-541e-463d-b2e8-59abab01d14b.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/ab40170d-541e-463d-b2e8-59abab01d14b.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-017",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "38",
     "rack": "BI-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/b5a84d92-6032-4234-9fcc-d5b488870ee6.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/b5a84d92-6032-4234-9fcc-d5b488870ee6.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-039",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "37",
     "rack": "BH-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/c44c80f3-ef4b-4115-a80a-0ed93c3b486f.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/c44c80f3-ef4b-4115-a80a-0ed93c3b486f.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-015",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "34",
     "rack": "BI-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d3ca4a4f-2319-4e88-9d63-6c8498f65820.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/d3ca4a4f-2319-4e88-9d63-6c8498f65820.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-037",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "40",
     "rack": "BG-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/e0477777-88fe-42ec-a686-87e646e02e81.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/e0477777-88fe-42ec-a686-87e646e02e81.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-033",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "32",
     "rack": "BG-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/e05f677a-d82b-4d41-9de2-751ad3167ccd.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/e05f677a-d82b-4d41-9de2-751ad3167ccd.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-018",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "40",
     "rack": "BI-41"

--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/feaecf87-dd11-4aad-8fe8-b8321262f340.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/feaecf87-dd11-4aad-8fe8-b8321262f340.json
@@ -72,7 +72,7 @@
     }
   ],
   "node_name": "P3-CPU-036",
-  "node_type": "compute_cascadelake_r",
+  "node_type": "compute_cascadelake_r_ib",
   "placement": {
     "node": "38",
     "rack": "BG-41"


### PR DESCRIPTION
add node type to make it clear which cascadelake nodes at UC have infiniband. This matches the convention at TACC.

Ideally, all nodes of a given "node_type" have identical hardware.