### PR TITLE
add discovered LIQID pcie devices

### DIFF
--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/0436edcc-3897-4796-8066-b7f7c3d4bac8.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/0436edcc-3897-4796-8066-b7f7c3d4bac8.json
@@ -14,6 +14,13 @@
     "name": "PowerEdge R6525",
     "serial": "D74FFF3"
   },
+  "gpu": {
+    "gpu": true,
+    "gpu_count": 1,
+    "gpu_model": "GA100 [A100 PCIe 40GB]",
+    "gpu_name": "A100",
+    "gpu_vendor": "NVIDIA Corporation"
+  },
   "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/3dfe5ff7-7783-4aec-a6d2-d51d815c32f2.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/3dfe5ff7-7783-4aec-a6d2-d51d815c32f2.json
@@ -14,6 +14,13 @@
     "name": "PowerEdge R6525",
     "serial": "D79CFF3"
   },
+  "gpu": {
+    "gpu": true,
+    "gpu_count": 1,
+    "gpu_model": "GA100 [A100 PCIe 40GB]",
+    "gpu_name": "A100",
+    "gpu_vendor": "NVIDIA Corporation"
+  },
   "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/a3da9ae6-86e7-492f-957a-01dfa318c081.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/a3da9ae6-86e7-492f-957a-01dfa318c081.json
@@ -14,6 +14,13 @@
     "name": "PowerEdge R6525",
     "serial": "D796FF3"
   },
+  "gpu": {
+    "gpu": true,
+    "gpu_count": 1,
+    "gpu_model": "GA100 [A100 PCIe 40GB]",
+    "gpu_name": "A100",
+    "gpu_vendor": "NVIDIA Corporation"
+  },
   "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/cdc504f0-2518-4caa-8b4d-3e2fe1d815a7.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/cdc504f0-2518-4caa-8b4d-3e2fe1d815a7.json
@@ -14,6 +14,13 @@
     "name": "PowerEdge R6525",
     "serial": "D766FF3"
   },
+  "gpu": {
+    "gpu": true,
+    "gpu_count": 2,
+    "gpu_model": "GA100 [A100 PCIe 40GB]",
+    "gpu_name": "A100",
+    "gpu_vendor": "NVIDIA Corporation"
+  },
   "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/cdf79e76-e771-45e1-8eb3-e1c1f6af1a7c.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/cdf79e76-e771-45e1-8eb3-e1c1f6af1a7c.json
@@ -14,6 +14,13 @@
     "name": "PowerEdge R6525",
     "serial": "D797FF3"
   },
+  "gpu": {
+    "gpu": true,
+    "gpu_count": 1,
+    "gpu_model": "GA100 [A100 PCIe 40GB]",
+    "gpu_name": "A100",
+    "gpu_vendor": "NVIDIA Corporation"
+  },
   "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/d4a46dc6-7cac-417f-800c-faea63a46130.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/d4a46dc6-7cac-417f-800c-faea63a46130.json
@@ -14,6 +14,13 @@
     "name": "PowerEdge R6525",
     "serial": "D764FF3"
   },
+  "gpu": {
+    "gpu": true,
+    "gpu_count": 2,
+    "gpu_model": "GA100 [A100 PCIe 40GB]",
+    "gpu_name": "A100",
+    "gpu_vendor": "NVIDIA Corporation"
+  },
   "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",
@@ -132,6 +139,26 @@
       "rev": "HG58",
       "size": 480103981056,
       "vendor": "SAMSUNG"
+    },
+    {
+      "device": "PCIeSSD.Slot.3-2",
+      "humanized_size": "3839 GB",
+      "interface": "PCIe",
+      "media_type": "SSD",
+      "model": "SAMSUNG MZ1LB3T8HMLA-00007",
+      "rev": "EDB7602Q",
+      "size": 3839700762624,
+      "vendor": "Samsung Electronics Co Ltd "
+    },
+    {
+      "device": "PCIeSSD.Slot.3-1",
+      "humanized_size": "3839 GB",
+      "interface": "PCIe",
+      "media_type": "SSD",
+      "model": "SAMSUNG MZ1LB3T8HMLA-00007",
+      "rev": "EDB7602Q",
+      "size": 3839700762624,
+      "vendor": "Samsung Electronics Co Ltd "
     }
   ],
   "supported_job_types": {

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/d9fa3550-7ac2-4e3b-a0ce-9228aabdd41d.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/d9fa3550-7ac2-4e3b-a0ce-9228aabdd41d.json
@@ -14,6 +14,13 @@
     "name": "PowerEdge R6525",
     "serial": "D795FF3"
   },
+  "gpu": {
+    "gpu": true,
+    "gpu_count": 1,
+    "gpu_model": "GA100 [A100 PCIe 40GB]",
+    "gpu_name": "A100",
+    "gpu_vendor": "NVIDIA Corporation"
+  },
   "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",


### PR DESCRIPTION
liqid01 shows firmware versions for the pcie SSDs, but the other devices do not.
The other nodes likely need a firmware update / OS loaded before the info will show up.