### PR TITLE
Add CODEOWNERS file to ensure changes get reviewed

### DIFF
--- a/data/chameleoncloud/sites/.github/CODEOWNERS
+++ b/data/chameleoncloud/sites/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Global
+* @msherman64 @codyhammock
+
+# Site Specific
+/data/chameleoncloud/sites/uc   @msherman64
+/data/chameleoncloud/sites/tacc @codyhammock
+/data/chameleoncloud/sites/ncar @jtillots
+/data/chameleoncloud/sites/nu   @feiyeh
+/data/chameleoncloud/sites/iit  @alexandru-orhean


### PR DESCRIPTION
Added CODEOWNERS file. Global reviewers will be tagged on all requests. Site-specific owners will be tagged on requests matching their site's subdirs.