### PR TITLE
[TACC] Add compute_gigaio nodes

### DIFF
--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/132ba02d-76ba-4c6b-b974-1490d8d4bc16.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/132ba02d-76ba-4c6b-b974-1490d8d4bc16.json
@@ -1,0 +1,120 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 160
+  },
+  "bios": {
+    "release_date": "2022-09-14",
+    "vendor": "Dell",
+    "version": "1.8.2"
+  },
+  "chassis": {
+    "manufacturer": "Dell",
+    "name": "PowerEdge R650",
+    "serial": "HY7FGT3"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 269715628032
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eno12399",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:ce:90",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12409",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:ce:91",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12419",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:ce:92",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12429",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:ce:93",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "enp130s0np0",
+      "driver": "mlx5_core",
+      "enabled": true,
+      "mac": "b8:3f:d2:97:37:28",
+      "model": "MT28908 Family [ConnectX-6]",
+      "rate": 40000000000,
+      "vendor": "Mellanox"
+    },
+    {
+      "device": "eno8303",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "c8:4b:d6:84:ed:e6",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno8403",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "c8:4b:d6:84:ed:e7",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    }
+  ],
+  "node_name": "gigaio02",
+  "node_type": "compute_gigaio",
+  "processor": {
+    "cache_l1d": 49807,
+    "cache_l1i": 32768,
+    "cache_l2": 1310720,
+    "cache_l3": 62914560,
+    "clock_speed": 2411724800,
+    "instruction_set": "x86_64",
+    "model": "Intel(R) Xeon(R) Platinum 8380 CPU @ 2.30GHz",
+    "vendor": "Intel"
+  },
+  "storage_devices": [
+    {
+      "device": "sda",
+      "humanized_size": "480 GB",
+      "interface": "SAS",
+      "media_type": "SSD",
+      "model": "MTFDDAK480TDS",
+      "serial": "222539B91522",
+      "rev": "J004",
+      "size": 480103981056
+    }
+  ],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "132ba02d-76ba-4c6b-b974-1490d8d4bc16"
+}

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/79c56cfc-2206-456a-8829-4bc51163cee6.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/79c56cfc-2206-456a-8829-4bc51163cee6.json
@@ -1,0 +1,120 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 160
+  },
+  "bios": {
+    "release_date": "2022-09-14",
+    "vendor": "Dell",
+    "version": "1.8.2"
+  },
+  "chassis": {
+    "manufacturer": "Dell",
+    "name": "PowerEdge R650",
+    "serial": "9Y4FGT3"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 269715628032
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eno12399",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:b3:36",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12409",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:b3:37",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12419",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:b3:38",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12429",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:b3:39",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "enp130s0np0",
+      "driver": "mlx5_core",
+      "enabled": true,
+      "mac": "b8:3f:d2:97:37:00",
+      "model": "MT28908 Family [ConnectX-6]",
+      "rate": 40000000000,
+      "vendor": "Mellanox"
+    },
+    {
+      "device": "eno8303",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "c8:4b:d6:84:eb:b4",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno8403",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "c8:4b:d6:84:eb:b5",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    }
+  ],
+  "node_name": "gigaio03",
+  "node_type": "compute_gigaio",
+  "processor": {
+    "cache_l1d": 49807,
+    "cache_l1i": 32768,
+    "cache_l2": 1310720,
+    "cache_l3": 62914560,
+    "clock_speed": 2411724800,
+    "instruction_set": "x86_64",
+    "model": "Intel(R) Xeon(R) Platinum 8380 CPU @ 2.30GHz",
+    "vendor": "Intel"
+  },
+  "storage_devices": [
+    {
+      "device": "sda",
+      "humanized_size": "480 GB",
+      "interface": "SAS",
+      "media_type": "SSD",
+      "model": "MTFDDAK480TDS",
+      "serial": "222539B8FB22",
+      "rev": "J004",
+      "size": 480103981056
+    }
+  ],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "79c56cfc-2206-456a-8829-4bc51163cee6"
+}

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/aec32a45-feea-41e3-8449-5859367a0a68.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/aec32a45-feea-41e3-8449-5859367a0a68.json
@@ -1,0 +1,120 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 160
+  },
+  "bios": {
+    "release_date": "2022-09-14",
+    "vendor": "Dell",
+    "version": "1.8.2"
+  },
+  "chassis": {
+    "manufacturer": "Dell",
+    "name": "PowerEdge R650",
+    "serial": "GZ7FGT3"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 269715628032
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eno12399",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:a4:ae",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12409",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:a4:af",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12419",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:a4:b0",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12429",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:a4:b1",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "enp152s0np0",
+      "driver": "mlx5_core",
+      "enabled": true,
+      "mac": "b8:3f:d2:97:2b:70",
+      "model": "MT28908 Family [ConnectX-6]",
+      "rate": 40000000000,
+      "vendor": "Mellanox"
+    },
+    {
+      "device": "eno8303",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "c8:4b:d6:83:10:56",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno8403",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "c8:4b:d6:83:10:57",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    }
+  ],
+  "node_name": "gigaio06",
+  "node_type": "compute_gigaio",
+  "processor": {
+    "cache_l1d": 49807,
+    "cache_l1i": 32768,
+    "cache_l2": 1310720,
+    "cache_l3": 62914560,
+    "clock_speed": 2411724800,
+    "instruction_set": "x86_64",
+    "model": "Intel(R) Xeon(R) Platinum 8380 CPU @ 2.30GHz",
+    "vendor": "Intel"
+  },
+  "storage_devices": [
+    {
+      "device": "sda",
+      "humanized_size": "480 GB",
+      "interface": "SAS",
+      "media_type": "SSD",
+      "model": "MTFDDAK480TDS",
+      "serial": "222539B91517",
+      "rev": "J004",
+      "size": 480103981056
+    }
+  ],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "aec32a45-feea-41e3-8449-5859367a0a68"
+}

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/b025a13c-4c49-416e-8e31-2373a1929e24.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/b025a13c-4c49-416e-8e31-2373a1929e24.json
@@ -1,0 +1,96 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 64
+  },
+  "bios": {
+    "release_date": "2019-08-15",
+    "vendor": "Dell",
+    "version": "2.3.10"
+  },
+  "chassis": {
+    "manufacturer": "Dell",
+    "name": "PowerEdge R740",
+    "serial": "HZVN903"
+  },
+  "main_memory": {
+    "humanized_ram_size": "192 GiB",
+    "ram_size": 201765408768
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eno3",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "b0:26:28:ea:ad:6e",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno4",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "b0:26:28:ea:ad:6f",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno1np0",
+      "driver": "bnxt_en",
+      "enabled": true,
+      "mac": "b0:26:28:ea:ad:70",
+      "model": "BCM57412 NetXtreme-E 10Gb RDMA Ethernet Controller",
+      "rate": 10000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno2np1",
+      "driver": "bnxt_en",
+      "enabled": true,
+      "mac": "b0:26:28:ea:ad:71",
+      "model": "BCM57412 NetXtreme-E 10Gb RDMA Ethernet Controller",
+      "rate": 10000000000,
+      "vendor": "Broadcom"
+    }
+  ],
+  "node_name": "c07-06",
+  "node_type": "compute_cascadelake",
+  "placement": {
+    "rack": "6"
+  },
+  "processor": {
+    "cache_l1d": 32768,
+    "cache_l1i": 32768,
+    "cache_l2": 1048576,
+    "cache_l3": 23068672,
+    "clock_speed": 2936012800,
+    "instruction_set": "x86_64",
+    "model": "Intel(R) Xeon(R) Gold 6242 CPU @ 2.80GHz",
+    "vendor": "Intel"
+  },
+  "storage_devices": [
+    {
+      "device": "sda",
+      "humanized_size": "240 GB",
+      "interface": "SAS",
+      "media_type": "SSD",
+      "model": "THNSF8240CCSE",
+      "serial": "39AS108BTCTQ",
+      "rev": "DACB",
+      "size": 240057409536
+    }
+  ],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "b025a13c-4c49-416e-8e31-2373a1929e24"
+}

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/d2376f39-b0ea-4648-b831-fdf84131066d.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/d2376f39-b0ea-4648-b831-fdf84131066d.json
@@ -1,0 +1,120 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 160
+  },
+  "bios": {
+    "release_date": "2022-09-14",
+    "vendor": "Dell",
+    "version": "1.8.2"
+  },
+  "chassis": {
+    "manufacturer": "Dell",
+    "name": "PowerEdge R650",
+    "serial": "8Y4FGT3"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 269715628032
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eno12399",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:cf:e6",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12409",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:cf:e7",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12419",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:cf:e8",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12429",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:cf:e9",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "enp130s0np0",
+      "driver": "mlx5_core",
+      "enabled": true,
+      "mac": "b8:3f:d2:97:50:18",
+      "model": "MT28908 Family [ConnectX-6]",
+      "rate": 40000000000,
+      "vendor": "Mellanox"
+    },
+    {
+      "device": "eno8303",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "c8:4b:d6:84:eb:a6",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno8403",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "c8:4b:d6:84:eb:a7",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    }
+  ],
+  "node_name": "gigaio04",
+  "node_type": "compute_gigaio",
+  "processor": {
+    "cache_l1d": 49807,
+    "cache_l1i": 32768,
+    "cache_l2": 1310720,
+    "cache_l3": 62914560,
+    "clock_speed": 2411724800,
+    "instruction_set": "x86_64",
+    "model": "Intel(R) Xeon(R) Platinum 8380 CPU @ 2.30GHz",
+    "vendor": "Intel"
+  },
+  "storage_devices": [
+    {
+      "device": "sda",
+      "humanized_size": "480 GB",
+      "interface": "SAS",
+      "media_type": "SSD",
+      "model": "MTFDDAK480TDS",
+      "serial": "222539B8FD1A",
+      "rev": "J004",
+      "size": 480103981056
+    }
+  ],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d2376f39-b0ea-4648-b831-fdf84131066d"
+}

--- a/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/d389fc04-f030-425d-8556-55b8d9ec12eb.json
+++ b/data/chameleoncloud/sites/tacc/clusters/chameleon/nodes/d389fc04-f030-425d-8556-55b8d9ec12eb.json
@@ -1,0 +1,120 @@
+{
+  "architecture": {
+    "platform_type": "x86_64",
+    "smp_size": 2,
+    "smt_size": 160
+  },
+  "bios": {
+    "release_date": "2022-09-14",
+    "vendor": "Dell",
+    "version": "1.8.2"
+  },
+  "chassis": {
+    "manufacturer": "Dell",
+    "name": "PowerEdge R650",
+    "serial": "DY4FGT3"
+  },
+  "main_memory": {
+    "humanized_ram_size": "256 GiB",
+    "ram_size": 269715628032
+  },
+  "monitoring": {
+    "wattmeter": false
+  },
+  "network_adapters": [
+    {
+      "device": "eno12399",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:cb:60",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12409",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:cb:61",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12419",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:cb:62",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno12429",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "00:62:0b:4b:cb:63",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "enp130s0np0",
+      "driver": "mlx5_core",
+      "enabled": true,
+      "mac": "b8:3f:d2:97:1f:e0",
+      "model": "MT28908 Family [ConnectX-6]",
+      "rate": 40000000000,
+      "vendor": "Mellanox"
+    },
+    {
+      "device": "eno8303",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "c8:4b:d6:84:f4:1a",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    },
+    {
+      "device": "eno8403",
+      "driver": "tg3",
+      "enabled": false,
+      "mac": "c8:4b:d6:84:f4:1b",
+      "model": "NetXtreme BCM5720 Gigabit Ethernet PCIe",
+      "rate": 1000000000,
+      "vendor": "Broadcom"
+    }
+  ],
+  "node_name": "gigaio01",
+  "node_type": "compute_gigaio",
+  "processor": {
+    "cache_l1d": 49807,
+    "cache_l1i": 32768,
+    "cache_l2": 1310720,
+    "cache_l3": 62914560,
+    "clock_speed": 2411724800,
+    "instruction_set": "x86_64",
+    "model": "Intel(R) Xeon(R) Platinum 8380 CPU @ 2.30GHz",
+    "vendor": "Intel"
+  },
+  "storage_devices": [
+    {
+      "device": "sda",
+      "humanized_size": "480 GB",
+      "interface": "SAS",
+      "media_type": "SSD",
+      "model": "MTFDDAK480TDS",
+      "serial": "222539B8FB48",
+      "rev": "J004",
+      "size": 480103981056
+    }
+  ],
+  "supported_job_types": {
+    "besteffort": false,
+    "deploy": true,
+    "virtual": "ivt"
+  },
+  "type": "node",
+  "uid": "d389fc04-f030-425d-8556-55b8d9ec12eb"
+}


### PR DESCRIPTION
This adds TACC's GigaIO nodes using data collected via Ironic Inspector