### PR TITLE
Manually fix gpu info for node missing inspection data

### DIFF
--- a/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/7ed407a7-98dd-4708-bf32-9e0ab50c9f68.json
+++ b/data/chameleoncloud/sites/uc/clusters/chameleon/nodes/7ed407a7-98dd-4708-bf32-9e0ab50c9f68.json
@@ -14,6 +14,9 @@
     "name": "PowerEdge R6525",
     "serial": "846ZJD3"
   },
+  "gpu": {
+    "gpu": false
+  },
   "infiniband": true,
   "main_memory": {
     "humanized_ram_size": "256 GiB",


### PR DESCRIPTION
This node is missing inspection data and fails validation on the new requirement that we have GPU info for each node.

This node doesn't look like it's been inspected in quite awhile:
```
| inspection_finished_at | None                                                                                                                                                                                      |
| inspection_started_at  | 2023-11-08T21:53:16+00:00  
```

Is there a case where we'd delete the node from the repo instead of fixing it like this? (And then if/when the node is fixed, presumably inspection would run and it would be added back later)