### PR TITLE
add kvm to site info for discovery

### DIFF
--- a/data/chameleoncloud/sites/kvm/clusters/chameleon.json
+++ b/data/chameleoncloud/sites/kvm/clusters/chameleon.json
@@ -1,0 +1,5 @@
+{
+  "created_at": "Tue, 08 Jun 2021 00:29:00 GMT",
+  "type": "cluster",
+  "uid": "chameleon"
+}

--- a/data/chameleoncloud/sites/kvm/kvm.json
+++ b/data/chameleoncloud/sites/kvm/kvm.json
@@ -1,0 +1,15 @@
+{
+  "description": "KVM Virtualized Site",
+  "email_contact": "help@chameleoncloud.org",
+  "latitude": 30.390223,
+  "location": "Austin, Texas, USA",
+  "longitude": -97.72563,
+  "name": "KVM@TACC",
+  "security_contact": "help@chameleoncloud.org",
+  "site_class": "kvm",
+  "sys_admin_contact": "help@chameleoncloud.org",
+  "type": "site",
+  "uid": "kvm",
+  "user_support_contact": "help@chameleoncloud.org",
+  "web": "https://kvm.tacc.chameleoncloud.org"
+}


### PR DESCRIPTION
similar to what we did for CHI@Edge, add the kvm site info.

Need to verify that this works correctly in horizon sites dropdown, portal hardware browser, and ccauth.

potential soluton for https://github.com/ChameleonCloud/ccauth/issues/7